### PR TITLE
Centralize auth-redirect logic, wire middleware, and improve registration UX

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -14,6 +14,10 @@ export default function LoginPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const isValidEmail = useMemo(() => /\S+@\S+\.\S+/.test(email), [email]);
+  const registrationMessage =
+    typeof window !== "undefined" && new URLSearchParams(window.location.search).get("registered") === "1"
+      ? "Registration successful. Please check your email to confirm your account if required."
+      : null;
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -62,6 +66,12 @@ export default function LoginPage() {
         <h1 className="text-2xl font-semibold text-gray-900">Login</h1>
 
         <form className="mt-6 space-y-4" onSubmit={onSubmit}>
+          {registrationMessage ? (
+            <p className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+              {registrationMessage}
+            </p>
+          ) : null}
+
           <div>
             <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-gray-700">
               Email

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -38,9 +38,17 @@ export default function RegisterPage() {
 
     try {
       const supabase = getSupabaseClient();
-      const { error: signUpError } = await supabase.auth.signUp({
+      const redirectTo =
+        typeof window !== "undefined" ? `${window.location.origin}/dashboard` : undefined;
+      const {
+        data: { session },
+        error: signUpError,
+      } = await supabase.auth.signUp({
         email,
         password,
+        options: {
+          emailRedirectTo: redirectTo,
+        },
       });
 
       if (signUpError) {
@@ -48,8 +56,16 @@ export default function RegisterPage() {
         return;
       }
 
-      router.push("/dashboard");
-      router.refresh();
+      if (session) {
+        router.push("/dashboard");
+        router.refresh();
+        return;
+      }
+
+      setEmail("");
+      setPassword("");
+      setConfirmPassword("");
+      router.replace("/login?registered=1");
     } catch (submitError) {
       setError(
         submitError instanceof Error

--- a/apps/web/lib/auth-redirect.mjs
+++ b/apps/web/lib/auth-redirect.mjs
@@ -1,0 +1,19 @@
+export function isProtectedRoute(pathname) {
+  return pathname.startsWith("/dashboard");
+}
+
+export function isAuthRoute(pathname) {
+  return pathname === "/login" || pathname === "/register";
+}
+
+export function resolveAuthRedirect(pathname, hasSession) {
+  if (!hasSession && isProtectedRoute(pathname)) {
+    return "/login";
+  }
+
+  if (hasSession && isAuthRoute(pathname)) {
+    return "/dashboard";
+  }
+
+  return null;
+}

--- a/apps/web/lib/auth-redirect.test.mjs
+++ b/apps/web/lib/auth-redirect.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isAuthRoute, isProtectedRoute, resolveAuthRedirect } from "./auth-redirect.mjs";
+
+test("isProtectedRoute identifies dashboard routes", () => {
+  assert.equal(isProtectedRoute("/dashboard"), true);
+  assert.equal(isProtectedRoute("/dashboard/settings"), true);
+  assert.equal(isProtectedRoute("/login"), false);
+});
+
+test("isAuthRoute identifies login and register routes", () => {
+  assert.equal(isAuthRoute("/login"), true);
+  assert.equal(isAuthRoute("/register"), true);
+  assert.equal(isAuthRoute("/dashboard"), false);
+});
+
+test("resolveAuthRedirect sends unauthenticated users to /login for protected routes", () => {
+  assert.equal(resolveAuthRedirect("/dashboard", false), "/login");
+  assert.equal(resolveAuthRedirect("/dashboard/positions", false), "/login");
+});
+
+test("resolveAuthRedirect sends authenticated users away from auth pages", () => {
+  assert.equal(resolveAuthRedirect("/login", true), "/dashboard");
+  assert.equal(resolveAuthRedirect("/register", true), "/dashboard");
+});
+
+test("resolveAuthRedirect returns null when no redirect is needed", () => {
+  assert.equal(resolveAuthRedirect("/login", false), null);
+  assert.equal(resolveAuthRedirect("/register", false), null);
+  assert.equal(resolveAuthRedirect("/dashboard", true), null);
+  assert.equal(resolveAuthRedirect("/", false), null);
+});

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,13 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerClient, type CookieOptions } from "@supabase/auth-helpers-nextjs";
-
-function isProtectedRoute(pathname: string) {
-  return pathname.startsWith("/dashboard");
-}
-
-function isAuthRoute(pathname: string) {
-  return pathname === "/login" || pathname === "/register";
-}
+import { isProtectedRoute, resolveAuthRedirect } from "@/lib/auth-redirect.mjs";
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next();
@@ -41,12 +34,9 @@ export async function middleware(req: NextRequest) {
     data: { session },
   } = await supabase.auth.getSession();
 
-  if (!session && isProtectedRoute(req.nextUrl.pathname)) {
-    return NextResponse.redirect(new URL("/login", req.url));
-  }
-
-  if (session && isAuthRoute(req.nextUrl.pathname)) {
-    return NextResponse.redirect(new URL("/dashboard", req.url));
+  const redirectPath = resolveAuthRedirect(req.nextUrl.pathname, Boolean(session));
+  if (redirectPath) {
+    return NextResponse.redirect(new URL(redirectPath, req.url));
   }
 
   return res;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "node --test lib/auth-redirect.test.mjs"
   },
   "dependencies": {
     "@supabase/auth-helpers-nextjs": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "web:lint": "npm --prefix apps/web run lint",
     "web:test": "npm --prefix apps/web run test"
   },
-  "devDependencies": {
+  "dependencies": {
     "next": "16.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "web:dev": "npm --prefix apps/web run dev",
     "web:build": "npm --prefix apps/web run build",
+    "web:build:vercel": "npm run web:build && rm -rf .next && cp -R apps/web/.next .next",
     "web:lint": "npm --prefix apps/web run lint",
     "web:test": "npm --prefix apps/web run test"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cycleiq",
+  "private": true,
+  "workspaces": [
+    "apps/web"
+  ],
+  "scripts": {
+    "web:dev": "npm --prefix apps/web run dev",
+    "web:build": "npm --prefix apps/web run build",
+    "web:lint": "npm --prefix apps/web run lint",
+    "web:test": "npm --prefix apps/web run test"
+  },
+  "devDependencies": {
+    "next": "16.2.4"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "installCommand": "npm --prefix apps/web install",
-  "buildCommand": "npm --prefix apps/web run build"
+  "installCommand": "npm install",
+  "buildCommand": "npm run web:build"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,5 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "npm install",
-  "buildCommand": "npm run web:build"
+  "buildCommand": "npm run web:build:vercel"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "npm --prefix apps/web install",
+  "buildCommand": "npm --prefix apps/web run build"
+}


### PR DESCRIPTION
### Motivation

- Centralize route-based auth redirect logic to remove duplication from middleware and make redirects easier to reason about.
- Improve the registration flow to handle email-confirmation flows and provide clear feedback to users after sign-up.

### Description

- Add `apps/web/lib/auth-redirect.mjs` exporting `isProtectedRoute`, `isAuthRoute`, and `resolveAuthRedirect` to encapsulate redirect rules.
- Update `apps/web/middleware.ts` to import and use `resolveAuthRedirect` for deciding redirects and remove duplicated route checks.
- Modify `apps/web/app/register/page.tsx` to pass `options.emailRedirectTo` to `supabase.auth.signUp`, handle returned `session` to immediately route authenticated users to `/dashboard`, and otherwise clear the form and `router.replace('/login?registered=1')` when sign-up requires confirmation.
- Modify `apps/web/app/login/page.tsx` to show a registration success message when the `registered=1` query parameter is present.
- Add `apps/web/lib/auth-redirect.test.mjs` with unit tests for the redirect helpers and add a `test` script to `apps/web/package.json` to run those tests via `node --test`.

### Testing

- Executed the auth redirect unit tests with `node --test lib/auth-redirect.test.mjs` and all tests passed.
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac897433083229fc624a8dbe35a79)