### PR TITLE
Harden issue metadata sync workflow for fork PRs

### DIFF
--- a/.github/workflows/sync-issue-metadata.yml
+++ b/.github/workflows/sync-issue-metadata.yml
@@ -12,7 +12,11 @@ permissions:
 
 jobs:
   sync:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # pull_request events from forks receive a read-only GITHUB_TOKEN.
+    # This job writes labels/milestone/comments, so skip fork-originated PRs.
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Sync labels, milestone, and project metadata from linked issue


### PR DESCRIPTION
### Motivation
- Prevent the sync job from attempting write actions (labels, milestone, comments, project sync) on pull requests opened from forked repos where `GITHUB_TOKEN` is read-only, which causes immediate permission failures.

### Description
- Updated `.github/workflows/sync-issue-metadata.yml` to add a job-level guard so the `sync` job only runs when the PR head repository matches the base repository and `head.repo.fork == false`, and added inline comments explaining the guard.

### Testing
- Inspected the updated workflow and diff with `nl -ba .github/workflows/sync-issue-metadata.yml` and `git diff` to confirm the new conditional (`github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.repo.fork == false`) and comments were applied, and verified the repository reflects the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacd6ff5ec83228b01ea3278bd4477)