### PR TITLE
Add pytest.ini to fix pytest module discovery for cycleiq

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
### Motivation
- `pytest -q` failed to collect tests due to `ModuleNotFoundError: No module named 'cycleiq'` because the test runner did not include the repository root on `PYTHONPATH`.

### Description
- Add a root-level `pytest.ini` with `pythonpath = .` so `pytest` can import the local `cycleiq` package without requiring `python -m pytest`.

### Testing
- Ran `pytest -q` and `python -m pytest -q` (both passed: 7 tests); ran `npm run web:test` (web unit tests passed: 5 tests); `npm run web:lint` failed in this environment due to the `eslint` package not being resolvable, which is an environment dependency issue rather than a code change failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec37c5f7f48322aff876236d1a3f53)