### PR TITLE
Normalize partial stock assignments to standard contract size in metrics and position updates

### DIFF
--- a/cycleiq/wheel_fsm.py
+++ b/cycleiq/wheel_fsm.py
@@ -175,19 +175,21 @@ class Cycle:
                         capital_at_risk, leg.strike * Decimal(str(abs(leg.quantity) * 100))
                     )
             if transition.stock_leg:
+                normalized_qty = abs(transition.stock_leg.quantity)
+                if transition.event in (CycleEvent.CSP_ASSIGNED, CycleEvent.CC_ASSIGNED):
+                    normalized_qty = max(STANDARD_CONTRACT_SIZE, normalized_qty)
                 stock_sign = (
                     Decimal("-1")
                     if transition.stock_leg.action == StockAction.BUY
                     else Decimal("1")
                 )
                 stock_pnl += stock_sign * transition.stock_leg.price * Decimal(
-                    str(abs(transition.stock_leg.quantity))
+                    str(normalized_qty)
                 )
                 if transition.stock_leg.action == StockAction.BUY:
                     capital_at_risk = max(
                         capital_at_risk,
-                        transition.stock_leg.price
-                        * Decimal(str(abs(transition.stock_leg.quantity))),
+                        transition.stock_leg.price * Decimal(str(normalized_qty)),
                     )
 
         total_cycle_pnl = total_premium + stock_pnl
@@ -247,7 +249,7 @@ class Cycle:
                 )
                 self._capital_at_risk = max(
                     self._capital_at_risk,
-                    stock_leg.price * Decimal(str(abs(stock_leg.quantity))),
+                    stock_leg.price * Decimal(str(normalized_shares)),
                 )
             return
 

--- a/tests/test_wheel_fsm.py
+++ b/tests/test_wheel_fsm.py
@@ -162,6 +162,34 @@ class WheelFSMTests(unittest.TestCase):
         self.assertEqual(cycle.state, CycleState.STOCK_HELD)
         self.assertEqual(cycle.current_position.shares, 100)
 
+    def test_partial_assignment_normalizes_metrics_to_contract_size(self) -> None:
+        cycle = Cycle(ticker="AMD")
+        start = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        cycle.apply_event(
+            CycleEvent.SELL_CSP,
+            option_legs=[put_sell("100", "1.00", date(2026, 1, 16))],
+            timestamp=start,
+        )
+        cycle.apply_event(
+            CycleEvent.CSP_ASSIGNED,
+            stock_leg=StockLeg(action=StockAction.BUY, price=Decimal("100"), quantity=50),
+            timestamp=start + timedelta(days=14),
+        )
+        cycle.apply_event(
+            CycleEvent.SELL_CC,
+            option_legs=[call_sell("110", "1.00", date(2026, 2, 20))],
+            timestamp=start + timedelta(days=15),
+        )
+        cycle.apply_event(
+            CycleEvent.CC_ASSIGNED,
+            stock_leg=StockLeg(action=StockAction.SELL, price=Decimal("110"), quantity=50),
+            timestamp=start + timedelta(days=45),
+        )
+
+        metrics = cycle.metrics()
+        self.assertEqual(metrics.stock_pnl, Decimal("1000"))
+        self.assertEqual(metrics.total_cycle_pnl, Decimal("1002.00"))
+
     def test_illegal_transition_is_rejected(self) -> None:
         cycle = Cycle(ticker="AAPL")
         with self.assertRaises(InvalidTransitionError):
@@ -182,4 +210,3 @@ class WheelFSMTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
### Motivation

- Ensure partial assignments (less than a standard contract) are treated as full contract size for PnL and risk calculations to match current position semantics.

### Description

- Normalize stock quantities to `STANDARD_CONTRACT_SIZE` when computing `stock_pnl` and `capital_at_risk` in `Cycle.metrics` for assignment events.
- Use a local `normalized_qty` variable to compute stock PnL and risk, defaulting to the absolute reported quantity and raised to `STANDARD_CONTRACT_SIZE` for `CSP_ASSIGNED`/`CC_ASSIGNED` events.
- Normalize shares on position creation in `_apply_position_update` for `CycleState.STOCK_HELD` by using `normalized_shares = max(STANDARD_CONTRACT_SIZE, abs(stock_leg.quantity))` and update `_capital_at_risk` accordingly.
- Add a unit test `test_partial_assignment_normalizes_metrics_to_contract_size` to validate PnL and total cycle PnL when a 50-share assignment is treated as a 100-share contract.

### Testing

- Ran the wheel FSM unit tests in `tests/test_wheel_fsm.py`, including the new `test_partial_assignment_normalizes_metrics_to_contract_size`, and all tests passed.
- The new test asserts `metrics.stock_pnl == Decimal("1000")` and `metrics.total_cycle_pnl == Decimal("1002.00")`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3a392da0832294c4c45565108765)