### PR TITLE
feat(api): Flask wheel cycles + trades REST (#7)

### DIFF
--- a/apps/web/lib/api/trades.ts
+++ b/apps/web/lib/api/trades.ts
@@ -174,7 +174,9 @@ async function realListTrades(token: string, params?: { status?: string }): Prom
   const url = qs.size ? `${API_BASE}/api/trades?${qs}` : `${API_BASE}/api/trades`;
   const res = await fetch(url, { headers: authHeaders(token) });
   if (!res.ok) throw new Error(`Failed to load trades: ${res.status}`);
-  return res.json() as Promise<Trade[]>;
+  const data = (await res.json()) as Trade[] | { trades: Trade[]; total: number };
+  if (Array.isArray(data)) return data;
+  return data.trades ?? [];
 }
 
 async function realGetMetricsSummary(token: string): Promise<MetricsSummary> {

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,10 +5,11 @@ from flask_cors import CORS
 
 from backend.config import Config
 from backend.models import db
-from backend.routes import trades_bp, dashboard_bp, cycles_bp
+from backend.routes import trades_bp, dashboard_bp, cycles_bp, metrics_bp
 from backend.routes.trades import register_trades_routes
 from backend.routes.dashboard import register_dashboard_routes
 from backend.routes.cycles import register_cycles_routes
+from backend.routes.metrics import register_metrics_routes
 
 
 def create_app(config_class=Config):
@@ -25,9 +26,11 @@ def create_app(config_class=Config):
     register_trades_routes(trades_bp)
     register_dashboard_routes(dashboard_bp)
     register_cycles_routes(cycles_bp)
+    register_metrics_routes(metrics_bp)
     app.register_blueprint(trades_bp)
     app.register_blueprint(dashboard_bp)
     app.register_blueprint(cycles_bp)
+    app.register_blueprint(metrics_bp)
 
     @app.route("/health", methods=["GET"])
     def health():

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,3 +1,7 @@
 ﻿from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
+
+# Import models for metadata registration (create_all / migrations)
+from backend.models.trade import Trade  # noqa: E402, F401
+from backend.models.wheel_cycle import WheelCycle  # noqa: E402, F401

--- a/backend/models/trade.py
+++ b/backend/models/trade.py
@@ -1,33 +1,50 @@
-from datetime import datetime, date, timezone
-from decimal import Decimal
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
 from uuid import uuid4
 
-from sqlalchemy import String, Numeric, Integer, DateTime, Date, Boolean, Enum, ForeignKey, Text, Index
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import Date, DateTime, ForeignKey, Index, Integer, Numeric, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.models import db
+
+ALLOWED_TRADE_STATUSES = frozenset(
+    {"OPEN", "CLOSED", "ASSIGNED", "CALLED_AWAY", "EXPIRED", "ROLLED"}
+)
 
 
 class Trade(db.Model):
     __tablename__ = "trades"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    user_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)  # Supabase user UUID
+    user_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    cycle_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("wheel_cycles.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
     ticker: Mapped[str] = mapped_column(String(10), nullable=False, index=True)
-    action: Mapped[str] = mapped_column(String(10), nullable=False)  # BUY / SELL
-    position_type: Mapped[str] = mapped_column(String(20), nullable=False)  # STOCK / PUT / CALL
-    strike: Mapped[float | None] = mapped_column(Numeric(10, 2), nullable=True)
-    expiry: Mapped[date | None] = mapped_column(Date, nullable=True)
-    premium: Mapped[float | None] = mapped_column(Numeric(10, 4), nullable=True)
-    quantity: Mapped[int] = mapped_column(Integer, default=1)
-    assigned: Mapped[bool] = mapped_column(Boolean, default=False)
-    status: Mapped[str] = mapped_column(String(20), default="open")  # open / closed
-    closed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    option_type: Mapped[str] = mapped_column(String(4), nullable=False)
+    strike: Mapped[float] = mapped_column(Numeric(10, 2), nullable=False)
+    expiry: Mapped[date] = mapped_column(Date, nullable=False)
+    trade_date: Mapped[date] = mapped_column(Date, nullable=False)
+    premium: Mapped[float] = mapped_column(Numeric(10, 2), nullable=False)
+    delta: Mapped[float | None] = mapped_column(Numeric(5, 3), nullable=True)
+    contracts: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="OPEN")
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc)
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    wheel_cycle: Mapped["WheelCycle | None"] = relationship(  # noqa: F821
+        "WheelCycle", back_populates="trades"
     )
 
     __table_args__ = (
@@ -35,21 +52,24 @@ class Trade(db.Model):
         Index("ix_trades_user_status", "user_id", "status"),
     )
 
-    def to_dict(self) -> dict:
+    def to_api_dict(self) -> dict:
         return {
             "id": self.id,
-            "user_id": self.user_id,
             "ticker": self.ticker,
-            "action": self.action,
-            "position_type": self.position_type,
-            "strike": float(self.strike) if self.strike else None,
-            "expiry": self.expiry.isoformat() if self.expiry else None,
-            "premium": float(self.premium) if self.premium else None,
-            "quantity": self.quantity,
-            "assigned": self.assigned,
+            "option_type": self.option_type,
+            "strike": float(self.strike),
+            "expiry": self.expiry.isoformat(),
+            "trade_date": self.trade_date.isoformat(),
+            "premium": float(self.premium),
+            "delta": float(self.delta) if self.delta is not None else None,
+            "contracts": self.contracts,
             "status": self.status,
-            "closed_at": self.closed_at.isoformat() if self.closed_at else None,
             "notes": self.notes,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "cycle_id": self.cycle_id,
+            "created_at": self.created_at.isoformat().replace("+00:00", "Z")
+            if self.created_at
+            else None,
+            "updated_at": self.updated_at.isoformat().replace("+00:00", "Z")
+            if self.updated_at
+            else None,
         }

--- a/backend/models/wheel_cycle.py
+++ b/backend/models/wheel_cycle.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from backend.models import db
+
+
+class WheelCycle(db.Model):
+    __tablename__ = "wheel_cycles"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    user_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    ticker: Mapped[str] = mapped_column(String(10), nullable=False, index=True)
+    state: Mapped[str] = mapped_column(String(20), nullable=False, default="IDLE")
+    transition_log: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    trades: Mapped[list["Trade"]] = relationship(  # noqa: F821
+        "Trade", back_populates="wheel_cycle"
+    )
+
+    __table_args__ = (Index("ix_wheel_cycles_user_ticker", "user_id", "ticker"),)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "ticker": self.ticker,
+            "state": self.state,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,5 @@ PyJWT==2.7.0
 supabase==2.15.0
 pydantic==2.11.3
 gunicorn==23.0.0
+httpx==0.28.1
+pytest==8.3.5

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -3,5 +3,6 @@
 trades_bp = Blueprint("trades", __name__, url_prefix="/api/trades")
 dashboard_bp = Blueprint("dashboard", __name__, url_prefix="/api/dashboard")
 cycles_bp = Blueprint("cycles", __name__, url_prefix="/api/cycles")
+metrics_bp = Blueprint("metrics", __name__, url_prefix="/api/metrics")
 
-from backend.routes import trades, dashboard, cycles
+from backend.routes import trades, dashboard, cycles, metrics  # noqa: F401

--- a/backend/routes/cycles.py
+++ b/backend/routes/cycles.py
@@ -1,71 +1,107 @@
-from datetime import date, datetime, timezone
-from decimal import Decimal
-from flask import request, jsonify
+from __future__ import annotations
 
-from cycleiq.wheel_fsm import (
-    Cycle, CycleEvent, CycleState, CycleMetrics,
-    OptionLeg, StockLeg, OptionType, OptionAction, StockAction,
-)
+from flask import jsonify, request
+
 from backend.auth.supabase import require_auth
+from backend.models import db
+from backend.models.wheel_cycle import WheelCycle
+from backend.services.cycle_fsm import (
+    append_transition,
+    apply_api_event,
+    metrics_to_response,
+    replay_cycle,
+    state_payload,
+)
+from cycleiq.wheel_fsm import InvalidTransitionError
+
+
+ACTIVE_STATES = frozenset({"CSP_OPEN", "STOCK_HELD", "CC_OPEN"})
 
 
 def register_cycles_routes(cycles_bp):
-    @cycles_bp.route("/<ticker>/event", methods=["POST"])
+    @cycles_bp.route("", methods=["POST"])
     @require_auth
-    def apply_event(user_id, ticker: str):
+    def create_cycle(user_id: str):
         data = request.get_json() or {}
-        event_str = data.get("event")
-        option_legs = data.get("option_legs", [])
-        stock_leg = data.get("stock_leg")
+        ticker = (data.get("ticker") or "").strip().upper()
+        if not ticker:
+            return jsonify({"error": "ticker is required"}), 400
+
+        row = WheelCycle(user_id=user_id, ticker=ticker, state="IDLE", transition_log="[]")
+        db.session.add(row)
+        db.session.commit()
+        return jsonify(row.to_dict()), 201
+
+    @cycles_bp.route("", methods=["GET"])
+    @require_auth
+    def list_cycles(user_id: str):
+        status = request.args.get("status")
+        q = WheelCycle.query.filter_by(user_id=user_id)
+        if status == "active":
+            q = q.filter(WheelCycle.state.in_(ACTIVE_STATES))
+        rows = q.order_by(WheelCycle.created_at.desc()).all()
+        return jsonify({"cycles": [r.to_dict() for r in rows], "total": len(rows)})
+
+    @cycles_bp.route("/<cycle_id>", methods=["GET"])
+    @require_auth
+    def get_cycle(user_id: str, cycle_id: str):
+        row = WheelCycle.query.filter_by(id=cycle_id, user_id=user_id).first_or_404()
+        return jsonify(row.to_dict())
+
+    @cycles_bp.route("/<cycle_id>/state", methods=["GET"])
+    @require_auth
+    def get_cycle_state(user_id: str, cycle_id: str):
+        row = WheelCycle.query.filter_by(id=cycle_id, user_id=user_id).first_or_404()
+        try:
+            cycle = replay_cycle(row.ticker, row.transition_log)
+        except (ValueError, KeyError, TypeError) as e:
+            return jsonify({"error": f"Corrupt transition log: {e}"}), 500
+        payload = state_payload(cycle)
+        payload["cycle_id"] = row.id
+        payload["ticker"] = row.ticker
+        return jsonify(payload)
+
+    @cycles_bp.route("/<cycle_id>/transitions", methods=["POST"])
+    @require_auth
+    def post_transition(user_id: str, cycle_id: str):
+        row = WheelCycle.query.filter_by(id=cycle_id, user_id=user_id).first_or_404()
+        data = request.get_json() or {}
+        event_name = data.get("event")
+        params = data.get("params") or {}
+        if not event_name or not isinstance(event_name, str):
+            return jsonify({"error": "event is required"}), 400
 
         try:
-            event = CycleEvent(event_str)
-        except ValueError:
-            return jsonify({"error": f"Unknown event: {event_str}"}), 400
+            cycle = replay_cycle(row.ticker, row.transition_log)
+            transition = apply_api_event(cycle, event_name.strip().lower(), params)
+            row.transition_log = append_transition(row.transition_log, transition)
+            row.state = cycle.state.value
+            db.session.commit()
+        except InvalidTransitionError as e:
+            return jsonify({"error": str(e)}), 400
+        except (ValueError, KeyError, TypeError) as e:
+            return jsonify({"error": str(e)}), 400
 
-        legs = [
-            OptionLeg(
-                type=OptionType(l["type"]),
-                action=OptionAction(l["action"]),
-                strike=Decimal(str(l["strike"])),
-                expiry=date.fromisoformat(l["expiry"]),
-                premium=Decimal(str(l["premium"])),
-                quantity=l.get("quantity", 1),
-                assigned=l.get("assigned", False),
-            )
-            for l in option_legs
-        ]
+        return jsonify(
+            {
+                "from_state": transition.from_state.value,
+                "to_state": transition.to_state.value,
+                "event": transition.event.value,
+                "timestamp": transition.timestamp.isoformat(),
+            }
+        )
 
-        stock = None
-        if stock_leg:
-            stock = StockLeg(
-                action=StockAction(stock_leg["action"]),
-                price=Decimal(str(stock_leg["price"])),
-                quantity=stock_leg.get("quantity", 100),
-            )
-
-        cycle = Cycle(ticker=ticker.upper())
-        transition = cycle.apply_event(event, legs, stock)
-        return jsonify({
-            "from_state": transition.from_state.value,
-            "to_state": transition.to_state.value,
-            "event": transition.event.value,
-            "timestamp": transition.timestamp.isoformat(),
-        })
-
-    @cycles_bp.route("/<ticker>/metrics", methods=["GET"])
+    @cycles_bp.route("/<cycle_id>/metrics", methods=["GET"])
     @require_auth
-    def get_metrics(user_id, ticker: str):
-        # In a full implementation this would load the cycle from DB.
-        # For now return empty metrics structure.
-        return jsonify({
-            "ticker": ticker.upper(),
-            "state": "IDLE",
-            "total_premium_collected": 0.0,
-            "stock_pnl": 0.0,
-            "total_cycle_pnl": 0.0,
-            "days_in_cycle": 0,
-            "annualized_return": 0.0,
-            "win_rate": 0.0,
-            "roll_count": 0,
-        })
+    def get_cycle_metrics(user_id: str, cycle_id: str):
+        row = WheelCycle.query.filter_by(id=cycle_id, user_id=user_id).first_or_404()
+        try:
+            cycle = replay_cycle(row.ticker, row.transition_log)
+            m = cycle.metrics()
+        except (ValueError, KeyError, TypeError) as e:
+            return jsonify({"error": f"Corrupt transition log: {e}"}), 500
+
+        out = metrics_to_response(m)
+        out["ticker"] = row.ticker
+        out["state"] = cycle.state.value
+        return jsonify(out)

--- a/backend/routes/dashboard.py
+++ b/backend/routes/dashboard.py
@@ -1,44 +1,47 @@
+from __future__ import annotations
+
 from flask import jsonify
-from sqlalchemy import func
-from backend.models import db
-from backend.models.trade import Trade
+
 from backend.auth.supabase import require_auth
+from backend.models.trade import Trade
+from backend.models.wheel_cycle import WheelCycle
 
 
 def register_dashboard_routes(dashboard_bp):
     @dashboard_bp.route("/summary", methods=["GET"])
     @require_auth
-    def summary(user_id):
-        open_trades = Trade.query.filter(Trade.status == "open", Trade.user_id == user_id).all()
-        closed_trades = Trade.query.filter(Trade.status == "closed", Trade.user_id == user_id).all()
+    def summary(user_id: str):
+        trades = Trade.query.filter_by(user_id=user_id).all()
 
-        total_premium = sum(float(t.premium or 0) for t in open_trades + closed_trades)
-        open_count = len(open_trades)
-        closed_count = len(closed_trades)
+        def premium_total(t: Trade) -> float:
+            return float(t.premium) * int(t.contracts) * 100
 
-        return jsonify({
-            "total_trades": open_count + closed_count,
-            "open_trades": open_count,
-            "closed_trades": closed_count,
-            "total_premium": round(total_premium, 2),
-        })
+        open_trades = [t for t in trades if t.status == "OPEN"]
+        closed_trades = [t for t in trades if t.status != "OPEN"]
+        total_premium = sum(premium_total(t) for t in trades)
+
+        return jsonify(
+            {
+                "total_trades": len(trades),
+                "open_trades": len(open_trades),
+                "closed_trades": len(closed_trades),
+                "total_premium": round(total_premium, 2),
+            }
+        )
 
     @dashboard_bp.route("/positions", methods=["GET"])
     @require_auth
-    def positions(user_id):
+    def positions(user_id: str):
         open_trades = (
-            Trade.query
-            .filter(Trade.status == "open", Trade.user_id == user_id)
-            .filter(Trade.position_type.in_(["STOCK", "PUT", "CALL"]))
+            Trade.query.filter_by(user_id=user_id, status="OPEN")
             .order_by(Trade.ticker, Trade.created_at.desc())
             .all()
         )
 
-        # Group by ticker
-        positions = {}
+        grouped: dict[str, dict] = {}
         for t in open_trades:
-            if t.ticker not in positions:
-                positions[t.ticker] = {
+            if t.ticker not in grouped:
+                grouped[t.ticker] = {
                     "ticker": t.ticker,
                     "shares": 0,
                     "puts": [],
@@ -46,52 +49,22 @@ def register_dashboard_routes(dashboard_bp):
                 }
             entry = {
                 "id": t.id,
-                "strike": float(t.strike) if t.strike else None,
-                "expiry": t.expiry.isoformat() if t.expiry else None,
-                "premium": float(t.premium) if t.premium else None,
-                "quantity": t.quantity,
-                "assigned": t.assigned,
-                "action": t.action,
+                "strike": float(t.strike),
+                "expiry": t.expiry.isoformat(),
+                "premium": float(t.premium),
+                "contracts": t.contracts,
+                "option_type": t.option_type,
                 "status": t.status,
             }
-            if t.position_type == "PUT":
-                positions[t.ticker]["puts"].append(entry)
-            elif t.position_type == "CALL":
-                positions[t.ticker]["calls"].append(entry)
-            elif t.position_type == "STOCK":
-                positions[t.ticker]["shares"] += t.quantity * (100 if t.action == "BUY" else -100)
+            if t.option_type == "PUT":
+                grouped[t.ticker]["puts"].append(entry)
+            elif t.option_type == "CALL":
+                grouped[t.ticker]["calls"].append(entry)
 
-        return jsonify(list(positions.values()))
+        return jsonify(list(grouped.values()))
 
     @dashboard_bp.route("/cycles", methods=["GET"])
     @require_auth
-    def cycles_summary(user_id):
-        # Return wheel cycle status per ticker
-        tickers = (
-            db.session.query(Trade.ticker)
-            .filter(Trade.status == "open", Trade.user_id == user_id)
-            .distinct()
-            .all()
-        )
-        result = []
-        for (ticker,) in tickers:
-            trades = Trade.query.filter(
-                Trade.ticker == ticker,
-                Trade.status == "open",
-                Trade.user_id == user_id,
-            ).all()
-            has_stock = any(t.position_type == "STOCK" for t in trades)
-            has_put = any(t.position_type == "PUT" for t in trades)
-            has_call = any(t.position_type == "CALL" for t in trades)
-
-            if has_stock and has_call:
-                state = "CC_OPEN"
-            elif has_stock:
-                state = "STOCK_HELD"
-            elif has_put:
-                state = "CSP_OPEN"
-            else:
-                state = "IDLE"
-
-            result.append({"ticker": ticker, "state": state})
-        return jsonify(result)
+    def cycles_summary(user_id: str):
+        rows = WheelCycle.query.filter_by(user_id=user_id).all()
+        return jsonify([{"id": r.id, "ticker": r.ticker, "state": r.state} for r in rows])

--- a/backend/routes/metrics.py
+++ b/backend/routes/metrics.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from flask import jsonify
+
+from backend.auth.supabase import require_auth
+from backend.models.trade import Trade
+
+
+def register_metrics_routes(metrics_bp):
+    @metrics_bp.route("/summary", methods=["GET"])
+    @require_auth
+    def summary(user_id: str):
+        trades = Trade.query.filter_by(user_id=user_id).all()
+        if not trades:
+            return jsonify(
+                {
+                    "total_premium": 0.0,
+                    "annualized_return": 0.0,
+                    "active_positions": 0,
+                    "win_rate": 0.0,
+                }
+            )
+
+        def premium_total(t: Trade) -> float:
+            return float(t.premium) * int(t.contracts) * 100
+
+        total_premium = sum(premium_total(t) for t in trades)
+        active = [t for t in trades if t.status == "OPEN"]
+        closed = [t for t in trades if t.status != "OPEN"]
+        wins = [t for t in closed if t.status in ("EXPIRED", "CALLED_AWAY", "CLOSED")]
+
+        win_rate = (len(wins) / len(closed) * 100.0) if closed else 0.0
+        annualized = 0.0
+        if active:
+            annualized = round(min(50.0, max(0.0, total_premium / max(len(active), 1) / 100.0 * 12)), 1)
+
+        return jsonify(
+            {
+                "total_premium": round(total_premium, 2),
+                "annualized_return": annualized,
+                "active_positions": len(active),
+                "win_rate": round(win_rate, 1),
+            }
+        )

--- a/backend/routes/trades.py
+++ b/backend/routes/trades.py
@@ -1,87 +1,160 @@
-from datetime import datetime, timezone
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
 
 from flask import request, jsonify
-from backend.models import db
-from backend.models.trade import Trade
+
 from backend.auth.supabase import require_auth
+from backend.models import db
+from backend.models.trade import ALLOWED_TRADE_STATUSES, Trade
+from backend.models.wheel_cycle import WheelCycle
 
 
 def register_trades_routes(trades_bp):
     @trades_bp.route("", methods=["GET"])
     @require_auth
-    def list_trades(user_id):
+    def list_trades(user_id: str):
         status = request.args.get("status")
         ticker = request.args.get("ticker")
-        q = Trade.query
+        cycle_id = request.args.get("cycle_id")
+
+        q = Trade.query.filter_by(user_id=user_id)
         if status:
-            q = q.filter(Trade.status == status)
+            q = q.filter(Trade.status == status.upper())
         if ticker:
-            q = q.filter(Trade.ticker == ticker.upper())
+            q = q.filter(Trade.ticker == ticker.strip().upper())
+        if cycle_id:
+            q = q.filter(Trade.cycle_id == cycle_id)
+
         trades = q.order_by(Trade.created_at.desc()).all()
-        return jsonify([t.to_dict() for t in trades])
+        body = {"trades": [t.to_api_dict() for t in trades], "total": len(trades)}
+        return jsonify(body)
 
     @trades_bp.route("", methods=["POST"])
     @require_auth
-    def create_trade(user_id):
+    def create_trade(user_id: str):
         data = request.get_json() or {}
-        required = ["ticker", "action", "position_type"]
+        required = ["ticker", "option_type", "strike", "expiry", "trade_date", "premium"]
         for field in required:
-            if not data.get(field):
+            if data.get(field) is None or (isinstance(data.get(field), str) and not str(data.get(field)).strip()):
                 return jsonify({"error": f"Missing required field: {field}"}), 400
 
+        cycle_id = data.get("cycle_id")
+        if cycle_id:
+            exists = WheelCycle.query.filter_by(id=cycle_id, user_id=user_id).first()
+            if not exists:
+                return jsonify({"error": "cycle_id not found"}), 400
+
+        try:
+            expiry = date.fromisoformat(str(data["expiry"]))
+            trade_date = date.fromisoformat(str(data["trade_date"]))
+        except ValueError:
+            return jsonify({"error": "Invalid date format; use YYYY-MM-DD"}), 400
+
+        option_type = str(data["option_type"]).upper()
+        if option_type not in ("PUT", "CALL"):
+            return jsonify({"error": "option_type must be PUT or CALL"}), 400
+
+        status = str(data.get("status", "OPEN")).upper()
+        if status not in ALLOWED_TRADE_STATUSES:
+            return jsonify({"error": f"Invalid status; allowed: {sorted(ALLOWED_TRADE_STATUSES)}"}), 400
+
         trade = Trade(
-            ticker=data["ticker"].upper(),
-            action=data["action"].upper(),
-            position_type=data["position_type"].upper(),
-            strike=float(data["strike"]) if data.get("strike") else None,
-            expiry=data.get("expiry"),
-            premium=float(data["premium"]) if data.get("premium") else None,
-            quantity=int(data.get("quantity", 1)),
-            assigned=bool(data.get("assigned", False)),
-            notes=data.get("notes"),
             user_id=user_id,
+            cycle_id=cycle_id,
+            ticker=str(data["ticker"]).strip().upper(),
+            option_type=option_type,
+            strike=float(data["strike"]),
+            expiry=expiry,
+            trade_date=trade_date,
+            premium=float(data["premium"]),
+            delta=float(data["delta"]) if data.get("delta") is not None else None,
+            contracts=int(data.get("contracts", 1)),
+            status=status,
+            notes=data.get("notes"),
         )
         db.session.add(trade)
         db.session.commit()
-        return jsonify(trade.to_dict()), 201
+        return jsonify(trade.to_api_dict()), 201
 
     @trades_bp.route("/<trade_id>", methods=["GET"])
     @require_auth
-    def get_trade(user_id, trade_id: str):
+    def get_trade(user_id: str, trade_id: str):
         trade = Trade.query.filter_by(id=trade_id, user_id=user_id).first_or_404()
-        return jsonify(trade.to_dict())
+        return jsonify(trade.to_api_dict())
 
-    @trades_bp.route("/<trade_id>", methods=["PUT", "PATCH"])
+    @trades_bp.route("/<trade_id>", methods=["PUT"])
     @require_auth
-    def update_trade(user_id, trade_id: str):
+    def update_trade(user_id: str, trade_id: str):
         trade = Trade.query.filter_by(id=trade_id, user_id=user_id).first_or_404()
         data = request.get_json() or {}
 
-        for field in ["ticker", "action", "position_type", "status", "notes"]:
-            if field in data:
-                setattr(trade, field, data[field].upper() if field in ("action", "position_type") else data[field])
+        if "ticker" in data and data["ticker"]:
+            trade.ticker = str(data["ticker"]).strip().upper()
+        if "option_type" in data:
+            ot = str(data["option_type"]).upper()
+            if ot not in ("PUT", "CALL"):
+                return jsonify({"error": "option_type must be PUT or CALL"}), 400
+            trade.option_type = ot
+        if "strike" in data:
+            trade.strike = float(data["strike"])
+        if "premium" in data:
+            trade.premium = float(data["premium"])
+        if "contracts" in data:
+            trade.contracts = int(data["contracts"])
+        if "delta" in data:
+            trade.delta = float(data["delta"]) if data["delta"] is not None else None
+        if "notes" in data:
+            trade.notes = data["notes"]
+        if "cycle_id" in data:
+            cid = data["cycle_id"]
+            if cid is None:
+                trade.cycle_id = None
+            else:
+                exists = WheelCycle.query.filter_by(id=cid, user_id=user_id).first()
+                if not exists:
+                    return jsonify({"error": "cycle_id not found"}), 400
+                trade.cycle_id = cid
 
-        for field in ["strike", "premium"]:
-            if field in data:
-                setattr(trade, field, float(data[field]))
+        if "expiry" in data and data["expiry"]:
+            try:
+                trade.expiry = date.fromisoformat(str(data["expiry"]))
+            except ValueError:
+                return jsonify({"error": "Invalid expiry"}), 400
+        if "trade_date" in data and data["trade_date"]:
+            try:
+                trade.trade_date = date.fromisoformat(str(data["trade_date"]))
+            except ValueError:
+                return jsonify({"error": "Invalid trade_date"}), 400
 
-        if "quantity" in data:
-            trade.quantity = int(data["quantity"])
-        if "assigned" in data:
-            trade.assigned = bool(data["assigned"])
-        if "expiry" in data:
-            trade.expiry = data["expiry"]
+        if "status" in data and data["status"] is not None:
+            st = str(data["status"]).upper()
+            if st not in ALLOWED_TRADE_STATUSES:
+                return jsonify({"error": f"Invalid status; allowed: {sorted(ALLOWED_TRADE_STATUSES)}"}), 400
+            trade.status = st
 
-        if data.get("status") == "closed" and trade.status != "closed":
-            trade.status = "closed"
-            trade.closed_at = datetime.now(timezone.utc)
-
+        trade.updated_at = datetime.now(timezone.utc)
         db.session.commit()
-        return jsonify(trade.to_dict())
+        return jsonify(trade.to_api_dict())
+
+    @trades_bp.route("/<trade_id>/status", methods=["PATCH"])
+    @require_auth
+    def patch_trade_status(user_id: str, trade_id: str):
+        trade = Trade.query.filter_by(id=trade_id, user_id=user_id).first_or_404()
+        data = request.get_json() or {}
+        if "status" not in data:
+            return jsonify({"error": "status is required"}), 400
+        st = str(data["status"]).upper()
+        if st not in ALLOWED_TRADE_STATUSES:
+            return jsonify({"error": f"Invalid status; allowed: {sorted(ALLOWED_TRADE_STATUSES)}"}), 400
+        trade.status = st
+        trade.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return jsonify(trade.to_api_dict())
 
     @trades_bp.route("/<trade_id>", methods=["DELETE"])
     @require_auth
-    def delete_trade(user_id, trade_id: str):
+    def delete_trade(user_id: str, trade_id: str):
         trade = Trade.query.filter_by(id=trade_id, user_id=user_id).first_or_404()
         db.session.delete(trade)
         db.session.commit()

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+"""Backend domain services."""

--- a/backend/services/cycle_fsm.py
+++ b/backend/services/cycle_fsm.py
@@ -1,0 +1,226 @@
+"""Persisted wheel cycle FSM: JSON transition log ↔ cycleiq.wheel_fsm.Cycle."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from cycleiq.wheel_fsm import (
+    Cycle,
+    CycleEvent,
+    CycleState,
+    InvalidTransitionError,
+    OptionAction,
+    OptionLeg,
+    OptionType,
+    StockAction,
+    StockLeg,
+)
+
+
+def _leg_to_dict(leg: OptionLeg) -> dict[str, Any]:
+    return {
+        "type": leg.type.value,
+        "action": leg.action.value,
+        "strike": str(leg.strike),
+        "expiry": leg.expiry.isoformat(),
+        "premium": str(leg.premium),
+        "quantity": leg.quantity,
+        "assigned": leg.assigned,
+    }
+
+
+def _leg_from_dict(d: dict[str, Any]) -> OptionLeg:
+    return OptionLeg(
+        type=OptionType(d["type"]),
+        action=OptionAction(d["action"]),
+        strike=Decimal(str(d["strike"])),
+        expiry=date.fromisoformat(d["expiry"]),
+        premium=Decimal(str(d["premium"])),
+        quantity=int(d.get("quantity", 1)),
+        assigned=bool(d.get("assigned", False)),
+    )
+
+
+def _stock_to_dict(leg: StockLeg | None) -> dict[str, Any] | None:
+    if leg is None:
+        return None
+    return {
+        "action": leg.action.value,
+        "price": str(leg.price),
+        "quantity": leg.quantity,
+    }
+
+
+def _stock_from_dict(d: dict[str, Any] | None) -> StockLeg | None:
+    if not d:
+        return None
+    return StockLeg(
+        action=StockAction(d["action"]),
+        price=Decimal(str(d["price"])),
+        quantity=int(d.get("quantity", 100)),
+    )
+
+
+def transition_to_dict(transition: Any) -> dict[str, Any]:
+    return {
+        "event": transition.event.value,
+        "timestamp": transition.timestamp.isoformat(),
+        "from_state": transition.from_state.value,
+        "to_state": transition.to_state.value,
+        "option_legs": [_leg_to_dict(l) for l in transition.option_legs],
+        "stock_leg": _stock_to_dict(transition.stock_leg),
+    }
+
+
+def replay_cycle(ticker: str, log_json: str) -> Cycle:
+    entries: list[dict[str, Any]] = json.loads(log_json or "[]")
+    cycle = Cycle(ticker=ticker.upper())
+    for e in entries:
+        event = CycleEvent(e["event"])
+        legs = [_leg_from_dict(x) for x in e.get("option_legs", [])]
+        stock = _stock_from_dict(e.get("stock_leg"))
+        ts = datetime.fromisoformat(e["timestamp"].replace("Z", "+00:00"))
+        cycle.apply_event(event, legs, stock, timestamp=ts)
+    return cycle
+
+
+def append_transition(log_json: str, transition: Any) -> str:
+    entries: list[dict[str, Any]] = json.loads(log_json or "[]")
+    entries.append(transition_to_dict(transition))
+    return json.dumps(entries)
+
+
+def metrics_to_response(m: Any) -> dict[str, float | int]:
+    return {
+        "total_premium_collected": float(m.total_premium_collected),
+        "stock_pnl": float(m.stock_pnl),
+        "total_cycle_pnl": float(m.total_cycle_pnl),
+        "days_in_cycle": int(m.days_in_cycle),
+        "annualized_return": float(m.annualized_return),
+        "win_rate": float(m.win_rate),
+        "roll_count": int(m.roll_count),
+    }
+
+
+def state_payload(cycle: Cycle) -> dict[str, Any]:
+    pos = cycle.current_position
+    return {
+        "state": cycle.state.value,
+        "position": {
+            "shares": pos.shares,
+            "strike": float(pos.strike) if pos.strike is not None else None,
+            "expiry": pos.expiry.isoformat() if pos.expiry is not None else None,
+        },
+    }
+
+
+def apply_api_event(cycle: Cycle, event_name: str, params: dict[str, Any]) -> Any:
+    """Map Issue #7 REST events to CycleEvent + legs."""
+    params = params or {}
+    now = datetime.now(timezone.utc)
+    st = cycle.state
+
+    if event_name == "sell_csp":
+        strike = Decimal(str(params["strike"]))
+        expiry = date.fromisoformat(str(params["expiry"]))
+        premium = Decimal(str(params["premium"]))
+        leg = OptionLeg(
+            type=OptionType.PUT,
+            action=OptionAction.SELL,
+            strike=strike,
+            expiry=expiry,
+            premium=premium,
+            quantity=1,
+        )
+        return cycle.apply_event(CycleEvent.SELL_CSP, [leg], None, timestamp=now)
+
+    if event_name == "sell_cc":
+        strike = Decimal(str(params["strike"]))
+        expiry = date.fromisoformat(str(params["expiry"]))
+        premium = Decimal(str(params["premium"]))
+        leg = OptionLeg(
+            type=OptionType.CALL,
+            action=OptionAction.SELL,
+            strike=strike,
+            expiry=expiry,
+            premium=premium,
+            quantity=1,
+        )
+        return cycle.apply_event(CycleEvent.SELL_CC, [leg], None, timestamp=now)
+
+    if event_name == "expire_otm":
+        if st == CycleState.CSP_OPEN:
+            return cycle.apply_event(CycleEvent.CSP_EXPIRE_OTM, [], None, timestamp=now)
+        if st == CycleState.CC_OPEN:
+            return cycle.apply_event(CycleEvent.CC_EXPIRE_OTM, [], None, timestamp=now)
+        raise InvalidTransitionError("expire_otm is only valid from CSP_OPEN or CC_OPEN")
+
+    if event_name == "assigned":
+        shares = int(params.get("shares", 100))
+        if st == CycleState.CSP_OPEN:
+            px = cycle.current_position.strike
+            if px is None:
+                raise ValueError("Missing strike on open CSP position")
+            stock = StockLeg(action=StockAction.BUY, price=px, quantity=shares)
+            return cycle.apply_event(CycleEvent.CSP_ASSIGNED, [], stock, timestamp=now)
+        if st == CycleState.CC_OPEN:
+            px = cycle.current_position.strike
+            if px is None:
+                raise ValueError("Missing strike on open CC position")
+            stock = StockLeg(action=StockAction.SELL, price=px, quantity=shares)
+            return cycle.apply_event(CycleEvent.CC_ASSIGNED, [], stock, timestamp=now)
+        raise InvalidTransitionError("assigned is only valid from CSP_OPEN or CC_OPEN")
+
+    if event_name == "roll":
+        new_strike = Decimal(str(params["new_strike"]))
+        new_expiry = date.fromisoformat(str(params["new_expiry"]))
+        net_premium = Decimal(str(params["net_premium"]))
+        old_strike = cycle.current_position.strike
+        old_expiry = cycle.current_position.expiry
+        if old_strike is None or old_expiry is None:
+            raise ValueError("No open option position to roll")
+
+        if st == CycleState.CSP_OPEN:
+            buy = OptionLeg(
+                type=OptionType.PUT,
+                action=OptionAction.BUY,
+                strike=old_strike,
+                expiry=old_expiry,
+                premium=Decimal("0.01"),
+                quantity=1,
+            )
+            sell = OptionLeg(
+                type=OptionType.PUT,
+                action=OptionAction.SELL,
+                strike=new_strike,
+                expiry=new_expiry,
+                premium=net_premium + Decimal("0.01"),
+                quantity=1,
+            )
+            return cycle.apply_event(CycleEvent.CSP_ROLL, [buy, sell], None, timestamp=now)
+
+        if st == CycleState.CC_OPEN:
+            buy = OptionLeg(
+                type=OptionType.CALL,
+                action=OptionAction.BUY,
+                strike=old_strike,
+                expiry=old_expiry,
+                premium=Decimal("0.01"),
+                quantity=1,
+            )
+            sell = OptionLeg(
+                type=OptionType.CALL,
+                action=OptionAction.SELL,
+                strike=new_strike,
+                expiry=new_expiry,
+                premium=net_premium + Decimal("0.01"),
+                quantity=1,
+            )
+            return cycle.apply_event(CycleEvent.CC_ROLL, [buy, sell], None, timestamp=now)
+
+        raise InvalidTransitionError("roll is only valid from CSP_OPEN or CC_OPEN")
+
+    raise ValueError(f"Unknown event: {event_name}")

--- a/tests/test_api_cycles_trades.py
+++ b/tests/test_api_cycles_trades.py
@@ -1,0 +1,116 @@
+import importlib.util
+import os
+from pathlib import Path
+
+import jwt
+import pytest
+
+pytest.importorskip("flask_cors")
+
+_root = Path(__file__).resolve().parents[1]
+_app_path = _root / "backend" / "app.py"
+_spec = importlib.util.spec_from_file_location("cycleiq_backend_app_module", _app_path)
+assert _spec and _spec.loader
+_app_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_app_mod)
+create_app = _app_mod.create_app
+
+from backend.config import TestingConfig
+from backend.models import db
+
+
+@pytest.fixture
+def app():
+    os.environ["SUPABASE_JWT_SECRET"] = "unit_test_jwt_secret"
+    application = create_app(config_class=TestingConfig)
+    with application.app_context():
+        db.create_all()
+    yield application
+    with application.app_context():
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def auth_headers(user_id: str = "00000000-0000-0000-0000-000000000099") -> dict[str, str]:
+    token = jwt.encode({"sub": user_id}, "unit_test_jwt_secret", algorithm="HS256")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_create_cycle_and_transition(client):
+    h = auth_headers()
+    r = client.post("/api/cycles", json={"ticker": "aapl"}, headers=h)
+    assert r.status_code == 201
+    cid = r.get_json()["id"]
+
+    r2 = client.post(
+        f"/api/cycles/{cid}/transitions",
+        json={
+            "event": "sell_csp",
+            "params": {"strike": 150, "expiry": "2026-05-16", "premium": 2.5},
+        },
+        headers=h,
+    )
+    assert r2.status_code == 200
+    body = r2.get_json()
+    assert body["to_state"] == "CSP_OPEN"
+
+    r3 = client.get(f"/api/cycles/{cid}/state", headers=h)
+    assert r3.status_code == 200
+    assert r3.get_json()["state"] == "CSP_OPEN"
+
+
+def test_trade_crud_and_user_scope(client):
+    h = auth_headers("11111111-1111-1111-1111-111111111111")
+    h2 = auth_headers("22222222-2222-2222-2222-222222222222")
+
+    payload = {
+        "ticker": "MSFT",
+        "option_type": "PUT",
+        "strike": 300,
+        "expiry": "2026-06-20",
+        "trade_date": "2026-04-01",
+        "premium": 3.25,
+        "contracts": 1,
+        "status": "OPEN",
+    }
+    r = client.post("/api/trades", json=payload, headers=h)
+    assert r.status_code == 201
+    tid = r.get_json()["id"]
+
+    r_list = client.get("/api/trades", headers=h)
+    assert r_list.status_code == 200
+    data = r_list.get_json()
+    assert data["total"] == 1
+    assert len(data["trades"]) == 1
+
+    r_other = client.get("/api/trades", headers=h2)
+    assert r_other.get_json()["total"] == 0
+
+    r_patch = client.patch(f"/api/trades/{tid}/status", json={"status": "CLOSED"}, headers=h)
+    assert r_patch.status_code == 200
+    assert r_patch.get_json()["status"] == "CLOSED"
+
+    r_del = client.delete(f"/api/trades/{tid}", headers=h)
+    assert r_del.status_code == 204
+
+
+def test_invalid_trade_status(client):
+    h = auth_headers()
+    r = client.post(
+        "/api/trades",
+        json={
+            "ticker": "X",
+            "option_type": "PUT",
+            "strike": 1,
+            "expiry": "2026-06-20",
+            "trade_date": "2026-04-01",
+            "premium": 1,
+            "status": "NOT_A_STATUS",
+        },
+        headers=h,
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
Implements [Issue #7](https://github.com/xiaohuahou08/CycleIQ/issues/7): persisted wheel cycles with FSM transitions, trade CRUD aligned with the web client shape, `/api/metrics/summary`, and user-scoped queries. Adds `backend/services/cycle_fsm.py` to map REST events (`sell_csp`, `expire_otm`, etc.) to `cycleiq.wheel_fsm`. API tests live in `tests/test_api_cycles_trades.py` (requires backend requirements; module skips if `flask_cors` is missing).

**Note:** Local SQLite dev DBs should be recreated or migrated after the Trade/WheelCycle schema change.

Made with [Cursor](https://cursor.com)