### PR TITLE
fix(web): header user menu with logout (#53)

### DIFF
--- a/apps/web/app/cycles/page.tsx
+++ b/apps/web/app/cycles/page.tsx
@@ -1,17 +1,18 @@
-import Link from "next/link";
+"use client";
+
+import { AuthenticatedShell } from "@/components/auth/AuthenticatedShell";
 
 export default function CyclesPage() {
   return (
-    <main className="min-h-screen bg-gray-50 px-6 py-10">
-      <div className="mx-auto max-w-3xl rounded-2xl bg-white p-8 shadow-sm">
-        <h1 className="text-2xl font-semibold text-gray-900">Cycles</h1>
-        <p className="mt-3 text-gray-600">
-          Wheel cycle tracking will appear here as the product MVP grows.
-        </p>
-        <Link href="/dashboard" className="mt-6 inline-block font-medium text-gray-900 underline">
-          Back to dashboard
-        </Link>
-      </div>
-    </main>
+    <AuthenticatedShell title="Cycles">
+      <main className="flex-1 px-6 py-10">
+        <div className="mx-auto max-w-3xl rounded-2xl bg-white p-8 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">Cycles</h1>
+          <p className="mt-3 text-gray-600">
+            Wheel cycle tracking will appear here as the product MVP grows.
+          </p>
+        </div>
+      </main>
+    </AuthenticatedShell>
   );
 }

--- a/apps/web/app/dashboard/components/Sidebar.tsx
+++ b/apps/web/app/dashboard/components/Sidebar.tsx
@@ -41,10 +41,9 @@ const sections: NavSection[] = [
 
 interface SidebarProps {
   email?: string | null;
-  onLogout?: () => void;
 }
 
-export default function Sidebar({ email, onLogout }: SidebarProps) {
+export default function Sidebar({ email }: SidebarProps) {
   const pathname = usePathname();
 
   return (
@@ -100,7 +99,7 @@ export default function Sidebar({ email, onLogout }: SidebarProps) {
         ))}
       </nav>
 
-      {/* User footer */}
+      {/* User footer — logout lives in the top header user menu */}
       <div className="border-t border-gray-200 px-4 py-3">
         <div className="flex items-center gap-2.5">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200 text-sm font-medium text-gray-700">
@@ -108,17 +107,8 @@ export default function Sidebar({ email, onLogout }: SidebarProps) {
           </div>
           <div className="min-w-0 flex-1">
             <p className="truncate text-xs text-gray-600">{email ?? "Signed in"}</p>
+            <p className="mt-0.5 text-[10px] text-gray-400">Account menu is top-right</p>
           </div>
-          {onLogout && (
-            <button
-              type="button"
-              onClick={onLogout}
-              className="text-xs text-gray-500 hover:text-gray-900"
-              title="Logout"
-            >
-              ↩
-            </button>
-          )}
         </div>
       </div>
     </aside>

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
   type MetricsSummary,
   type Trade,
 } from "@/lib/api/trades";
+import { UserMenu } from "@/components/auth/UserMenu";
 import Sidebar from "./components/Sidebar";
 import SummaryCards from "./components/SummaryCards";
 import ActivePositionsTable from "./components/ActivePositionsTable";
@@ -86,13 +87,6 @@ export default function DashboardPage() {
     }
   }, [token, loadData]);
 
-  const onLogout = async () => {
-    const supabase = getSupabaseClient();
-    await supabase.auth.signOut();
-    router.push("/login");
-    router.refresh();
-  };
-
   const onSaveTrade = async (input: CreateTradeInput) => {
     if (!token) return;
     setSaveError(null);
@@ -132,40 +126,38 @@ export default function DashboardPage() {
           sidebarOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
-        <Sidebar email={email} onLogout={onLogout} />
+        <Sidebar email={email} />
       </div>
 
       {/* Main content */}
       <div className="flex flex-1 flex-col overflow-auto">
-        {/* Mobile topbar */}
-        <div className="flex items-center border-b border-gray-200 bg-white px-4 py-3 lg:hidden">
-          <button
-            type="button"
-            onClick={() => setSidebarOpen(true)}
-            className="mr-3 rounded-lg p-1.5 text-gray-500 hover:bg-gray-100"
-            aria-label="Open navigation"
-          >
-            ☰
-          </button>
-          <span className="text-sm font-semibold text-gray-900">CycleIQ</span>
+        <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-gray-200 bg-white px-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setSidebarOpen(true)}
+              className="rounded-lg p-1.5 text-gray-500 hover:bg-gray-100 lg:hidden"
+              aria-label="Open navigation"
+            >
+              ☰
+            </button>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-gray-900 lg:text-base">Dashboard</p>
+              <p className="hidden truncate text-xs text-gray-500 sm:block">Your wheel strategy at a glance</p>
+            </div>
+          </div>
+          <UserMenu email={email} />
         </div>
 
         <main className="flex-1 px-6 py-8">
-          {/* Page header */}
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
-              <p className="mt-1 text-sm text-gray-500">
-                Your wheel strategy at a glance
-              </p>
-            </div>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-end">
             <button
               type="button"
               onClick={() => {
                 setSaveError(null);
                 setModalOpen(true);
               }}
-              className="rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-medium text-white hover:bg-gray-800"
+              className="rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-medium text-white hover:bg-gray-800 sm:shrink-0"
             >
               + Add Trade
             </button>

--- a/apps/web/app/orders/page.tsx
+++ b/apps/web/app/orders/page.tsx
@@ -1,15 +1,18 @@
-import Link from "next/link";
+"use client";
+
+import { AuthenticatedShell } from "@/components/auth/AuthenticatedShell";
 
 export default function OrdersPage() {
   return (
-    <main className="min-h-screen bg-gray-50 px-6 py-10">
-      <div className="mx-auto max-w-3xl rounded-2xl bg-white p-8 shadow-sm">
-        <h1 className="text-2xl font-semibold text-gray-900">Orders</h1>
-        <p className="mt-3 text-gray-600">Order intents and approvals will surface here when wired to the OMS.</p>
-        <Link href="/dashboard" className="mt-6 inline-block font-medium text-gray-900 underline">
-          Back to dashboard
-        </Link>
-      </div>
-    </main>
+    <AuthenticatedShell title="Orders">
+      <main className="flex-1 px-6 py-10">
+        <div className="mx-auto max-w-3xl rounded-2xl bg-white p-8 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">Orders</h1>
+          <p className="mt-3 text-gray-600">
+            Order intents and approvals will surface here when wired to the OMS.
+          </p>
+        </div>
+      </main>
+    </AuthenticatedShell>
   );
 }

--- a/apps/web/app/reports/page.tsx
+++ b/apps/web/app/reports/page.tsx
@@ -1,15 +1,16 @@
-import Link from "next/link";
+"use client";
+
+import { AuthenticatedShell } from "@/components/auth/AuthenticatedShell";
 
 export default function ReportsPage() {
   return (
-    <main className="min-h-screen bg-gray-50 px-6 py-10">
-      <div className="mx-auto max-w-3xl rounded-2xl bg-white p-8 shadow-sm">
-        <h1 className="text-2xl font-semibold text-gray-900">Reports</h1>
-        <p className="mt-3 text-gray-600">Analytics and exports will be available in a future iteration.</p>
-        <Link href="/dashboard" className="mt-6 inline-block font-medium text-gray-900 underline">
-          Back to dashboard
-        </Link>
-      </div>
-    </main>
+    <AuthenticatedShell title="Reports">
+      <main className="flex-1 px-6 py-10">
+        <div className="mx-auto max-w-3xl rounded-2xl bg-white p-8 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">Reports</h1>
+          <p className="mt-3 text-gray-600">Reporting views will be added in upcoming milestones.</p>
+        </div>
+      </main>
+    </AuthenticatedShell>
   );
 }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,15 +1,16 @@
-import Link from "next/link";
+"use client";
+
+import { AuthenticatedShell } from "@/components/auth/AuthenticatedShell";
 
 export default function SettingsPage() {
   return (
-    <main className="min-h-screen bg-gray-50 px-6 py-10">
-      <div className="mx-auto max-w-3xl rounded-2xl bg-white p-8 shadow-sm">
-        <h1 className="text-2xl font-semibold text-gray-900">Settings</h1>
-        <p className="mt-3 text-gray-600">Account and application preferences will live here.</p>
-        <Link href="/dashboard" className="mt-6 inline-block font-medium text-gray-900 underline">
-          Back to dashboard
-        </Link>
-      </div>
-    </main>
+    <AuthenticatedShell title="Settings">
+      <main className="flex-1 px-6 py-10">
+        <div className="mx-auto max-w-3xl rounded-2xl bg-white p-8 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">Settings</h1>
+          <p className="mt-3 text-gray-600">Account and application preferences will live here.</p>
+        </div>
+      </main>
+    </AuthenticatedShell>
   );
 }

--- a/apps/web/app/trades/page.tsx
+++ b/apps/web/app/trades/page.tsx
@@ -9,6 +9,7 @@ import {
   type CreateTradeInput,
   type Trade,
 } from "@/lib/api/trades";
+import { UserMenu } from "@/components/auth/UserMenu";
 import { getSupabaseClient } from "@/lib/supabase/client";
 import TradeFilters, { type FilterState } from "./components/TradeFilters";
 import TradeList from "./components/TradeList";
@@ -37,12 +38,10 @@ function applyFilters(trades: Trade[], f: FilterState): Trade[] {
 
 function Sidebar({
   email,
-  onLogout,
   mobileOpen,
   onClose,
 }: {
   email: string | null;
-  onLogout: () => void;
   mobileOpen: boolean;
   onClose: () => void;
 }) {
@@ -90,16 +89,9 @@ function Sidebar({
           ))}
         </nav>
 
-        {/* User */}
         <div className="border-t border-gray-100 px-4 py-4">
           <p className="truncate text-xs text-gray-400">{email ?? "—"}</p>
-          <button
-            type="button"
-            onClick={onLogout}
-            className="mt-2 text-sm text-gray-500 hover:text-gray-700"
-          >
-            Sign out
-          </button>
+          <p className="mt-2 text-[10px] text-gray-400">Account menu is top-right</p>
         </div>
       </aside>
     </>
@@ -182,12 +174,6 @@ export default function TradesPage() {
     await deleteTrade(token, id);
   };
 
-  const onLogout = async () => {
-    await getSupabaseClient().auth.signOut();
-    router.push("/login");
-    router.refresh();
-  };
-
   const filtered = applyFilters(allTrades, filters);
 
   if (isAuthLoading) {
@@ -203,35 +189,32 @@ export default function TradesPage() {
       {/* Sidebar */}
       <Sidebar
         email={email}
-        onLogout={onLogout}
         mobileOpen={sidebarOpen}
         onClose={() => setSidebarOpen(false)}
       />
 
       {/* Main content */}
       <div className="flex flex-1 flex-col overflow-auto">
-        {/* Mobile topbar */}
-        <div className="flex items-center border-b border-gray-200 bg-white px-4 py-3 lg:hidden">
-          <button
-            type="button"
-            onClick={() => setSidebarOpen(true)}
-            className="mr-3 rounded-lg p-1.5 text-gray-500 hover:bg-gray-100"
-            aria-label="Open navigation"
-          >
-            ☰
-          </button>
-          <span className="text-sm font-semibold text-gray-900">CycleIQ</span>
+        <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-gray-200 bg-white px-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setSidebarOpen(true)}
+              className="rounded-lg p-1.5 text-gray-500 hover:bg-gray-100 lg:hidden"
+              aria-label="Open navigation"
+            >
+              ☰
+            </button>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-gray-900 lg:text-base">Trades</p>
+              <p className="hidden truncate text-xs text-gray-500 sm:block">All your wheel strategy trades</p>
+            </div>
+          </div>
+          <UserMenu email={email} />
         </div>
 
         <main className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
-          {/* Page header */}
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900">Trades</h1>
-              <p className="mt-1 text-sm text-gray-500">
-                All your wheel strategy trades
-              </p>
-            </div>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-end">
             <button
               type="button"
               onClick={() => { setSaveError(null); setModalOpen(true); }}

--- a/apps/web/components/auth/AuthenticatedShell.tsx
+++ b/apps/web/components/auth/AuthenticatedShell.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { getSupabaseClient } from "@/lib/supabase/client";
+import { UserMenu } from "@/components/auth/UserMenu";
+
+export function AuthenticatedShell({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const [email, setEmail] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const run = async () => {
+      try {
+        const supabase = getSupabaseClient();
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+        if (!session) {
+          router.replace("/login");
+          return;
+        }
+        setEmail(session.user.email ?? null);
+      } catch {
+        router.replace("/login");
+      } finally {
+        setLoading(false);
+      }
+    };
+    void run();
+  }, [router]);
+
+  if (loading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-gray-50">
+        <p className="text-gray-600">Loading…</p>
+      </main>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-50">
+      <header className="flex h-14 shrink-0 items-center justify-between border-b border-gray-200 bg-white px-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <Link href="/dashboard" className="shrink-0 text-base font-semibold text-gray-900">
+            CycleIQ
+          </Link>
+          <span className="truncate text-sm text-gray-500">{title}</span>
+        </div>
+        <UserMenu email={email} />
+      </header>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/components/auth/UserMenu.tsx
+++ b/apps/web/components/auth/UserMenu.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { getSupabaseClient } from "@/lib/supabase/client";
+
+export function UserMenu({ email }: { email: string | null }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onDocMouseDown(e: MouseEvent) {
+      if (!rootRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
+  const onLogout = async () => {
+    setOpen(false);
+    const supabase = getSupabaseClient();
+    await supabase.auth.signOut();
+    router.push("/login");
+    router.refresh();
+  };
+
+  const initial = email?.trim()?.[0]?.toUpperCase() ?? "?";
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-sm shadow-sm hover:bg-gray-50"
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-sm font-medium text-gray-800">
+          {initial}
+        </span>
+        <span className="hidden max-w-[10rem] truncate text-left text-gray-700 sm:inline">
+          {email ?? "Account"}
+        </span>
+        <span className="text-gray-400" aria-hidden>
+          ▾
+        </span>
+      </button>
+
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 z-50 mt-2 w-52 rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+        >
+          <div className="px-3 py-2 text-xs text-gray-400" role="presentation">
+            Signed in as
+            <div className="truncate text-sm text-gray-800">{email ?? "—"}</div>
+          </div>
+          <div className="my-1 border-t border-gray-100" />
+          <span
+            className="block cursor-not-allowed px-3 py-2 text-sm text-gray-400"
+            role="menuitem"
+          >
+            Profile <span className="text-xs">(soon)</span>
+          </span>
+          <Link
+            href="/settings"
+            role="menuitem"
+            className="block px-3 py-2 text-sm text-gray-800 hover:bg-gray-50"
+            onClick={() => setOpen(false)}
+          >
+            Settings
+          </Link>
+          <button
+            type="button"
+            role="menuitem"
+            className="w-full px-3 py-2 text-left text-sm text-gray-800 hover:bg-gray-50"
+            onClick={() => {
+              void onLogout();
+            }}
+          >
+            Log out
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/auth-redirect.mjs
+++ b/apps/web/lib/auth-redirect.mjs
@@ -1,6 +1,7 @@
 export function isProtectedRoute(pathname) {
   return (
     pathname.startsWith("/dashboard") ||
+    pathname.startsWith("/trades") ||
     pathname.startsWith("/cycles") ||
     pathname.startsWith("/reports") ||
     pathname.startsWith("/settings") ||
@@ -14,6 +15,7 @@ export function isAuthRoute(pathname) {
 
 const ALLOWED_POST_LOGIN_PREFIXES = [
   "/dashboard",
+  "/trades",
   "/cycles",
   "/reports",
   "/settings",

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -53,6 +53,7 @@ export async function middleware(req: NextRequest) {
 export const config = {
   matcher: [
     "/dashboard/:path*",
+    "/trades/:path*",
     "/cycles/:path*",
     "/reports/:path*",
     "/settings/:path*",


### PR DESCRIPTION
Closes [Issue #53](https://github.com/xiaohuahou08/CycleIQ/issues/53).

- Adds a top-right **User** menu (avatar + email) with **Log out** calling `supabase.auth.signOut()` and redirecting to `/login`.
- Uses the same menu on **Dashboard** and **Trades** (visible on desktop and mobile).
- Wraps **Cycles / Orders / Reports / Settings** in `AuthenticatedShell` so those routes also expose the menu after login.
- Treats `/trades` as a protected route in middleware and allows it for safe `next=` redirects after auth.

Made with [Cursor](https://cursor.com)