### PR TITLE
feat(trades): implement expire workflow and edit modal for issue #63

### DIFF
--- a/apps/web/app/(protected)/dashboard/components/AddTradeModal.tsx
+++ b/apps/web/app/(protected)/dashboard/components/AddTradeModal.tsx
@@ -98,6 +98,9 @@ interface AddTradeModalProps {
   onClose: () => void;
   onSave: (input: CreateTradeInput) => Promise<void>;
   tickerSuggestions?: string[];
+  initialValues?: Partial<CreateTradeInput>;
+  title?: string;
+  submitLabel?: string;
 }
 
 export default function AddTradeModal({
@@ -105,6 +108,9 @@ export default function AddTradeModal({
   onClose,
   onSave,
   tickerSuggestions = [],
+  initialValues,
+  title = "Add Trade",
+  submitLabel = "Save Trade",
 }: AddTradeModalProps) {
   const [showOptionalFields, setShowOptionalFields] = useState(true);
   const [commissionFees, setCommissionFees] = useState<string>("");
@@ -155,18 +161,18 @@ export default function AddTradeModal({
       setShowOptionalFields(true);
       setCommissionFees("");
       reset({
-        option_type: "PUT",
-        contracts: 1,
-        expiry: defaultExpiry(),
-        trade_date: today(),
-        ticker: "",
-        strike: undefined,
-        premium: undefined,
-        delta: undefined,
-        notes: "",
+        option_type: initialValues?.option_type ?? "PUT",
+        contracts: initialValues?.contracts ?? 1,
+        expiry: initialValues?.expiry ?? defaultExpiry(),
+        trade_date: initialValues?.trade_date ?? today(),
+        ticker: initialValues?.ticker ?? "",
+        strike: initialValues?.strike,
+        premium: initialValues?.premium,
+        delta: initialValues?.delta,
+        notes: initialValues?.notes ?? "",
       });
     }
-  }, [open, reset]);
+  }, [open, reset, initialValues]);
 
   useEffect(() => {
     const onMouseMove = (event: MouseEvent) => {
@@ -224,7 +230,7 @@ export default function AddTradeModal({
       trade_date: values.trade_date,
       premium: values.premium,
       contracts: values.contracts,
-      status: "OPEN",
+      status: initialValues?.status ?? "OPEN",
       delta: values.delta === "" ? undefined : (values.delta as number | undefined),
       notes: notesToSubmit,
     };
@@ -251,7 +257,7 @@ export default function AddTradeModal({
           onMouseDown={onDragStart}
         >
           <h2 id="add-trade-title" className="text-base font-semibold text-gray-900">
-            Add Trade
+            {title}
           </h2>
           <button
             type="button"
@@ -562,7 +568,7 @@ export default function AddTradeModal({
               disabled={isSubmitting}
               className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isSubmitting ? "Saving…" : "Save Trade"}
+              {isSubmitting ? "Saving…" : submitLabel}
             </button>
           </div>
         </form>

--- a/apps/web/app/(protected)/trades/components/TradeList.tsx
+++ b/apps/web/app/(protected)/trades/components/TradeList.tsx
@@ -54,6 +54,15 @@ function getDte(expiry: string): number {
   return Math.max(0, Math.ceil(diffMs / (1000 * 60 * 60 * 24)));
 }
 
+function isExpiredEligible(trade: Trade): boolean {
+  if (trade.status !== "OPEN") return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const expiry = new Date(trade.expiry);
+  expiry.setHours(0, 0, 0, 0);
+  return expiry <= today;
+}
+
 function startOfWeekMonday(input: Date): Date {
   const d = new Date(input);
   const day = d.getDay();
@@ -245,16 +254,18 @@ function TradeRow({
               >
                 Buy to Close
               </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setMenuOpen(false);
-                  onAction("expire");
-                }}
-                className="block w-full px-3 py-2 hover:bg-gray-50"
-              >
-                Expire
-              </button>
+              {isExpiredEligible(trade) && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onAction("expire");
+                  }}
+                  className="block w-full px-3 py-2 hover:bg-gray-50"
+                >
+                  Expire
+                </button>
+              )}
               <button
                 type="button"
                 onClick={() => {

--- a/apps/web/app/(protected)/trades/page.tsx
+++ b/apps/web/app/(protected)/trades/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   createTrade,
   deleteTrade,
+  expireTrade,
   listTrades,
   postCycleTransition,
   updateTrade,
@@ -39,6 +40,7 @@ export default function TradesPage() {
   const [allTrades, setAllTrades] = useState<Trade[]>([]);
   const [tradesLoading, setTradesLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
+  const [editingTrade, setEditingTrade] = useState<Trade | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [filters, setFilters] = useState<FilterState>({
     ticker: "",
@@ -82,22 +84,29 @@ export default function TradesPage() {
     }
   };
 
+  const onSaveEditedTrade = async (input: CreateTradeInput) => {
+    if (!token || !editingTrade) return;
+    setSaveError(null);
+    try {
+      const updated = await updateTrade(token, editingTrade.id, input);
+      setAllTrades((prev) => prev.map((t) => (t.id === editingTrade.id ? updated : t)));
+      setModalOpen(false);
+      setEditingTrade(null);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to update trade.");
+    }
+  };
+
   const onDeleteTrade = async (id: string) => {
     if (!token) return;
     setAllTrades((prev) => prev.filter((t) => t.id !== id));
     await deleteTrade(token, id);
   };
 
-  const onEditTrade = async (trade: Trade) => {
-    if (!token) return;
-    const notes = window.prompt("Edit notes", trade.notes ?? "");
-    if (notes === null) return;
-    try {
-      const updated = await updateTrade(token, trade.id, { notes });
-      setAllTrades((prev) => prev.map((t) => (t.id === trade.id ? updated : t)));
-    } catch (err) {
-      setSaveError(err instanceof Error ? err.message : "Failed to update trade.");
-    }
+  const onEditTrade = (trade: Trade) => {
+    setSaveError(null);
+    setEditingTrade(trade);
+    setModalOpen(true);
   };
 
   const onAction = async (
@@ -113,10 +122,24 @@ export default function TradesPage() {
       }
 
       if (action === "expire") {
-        if (trade.cycle_id) {
-          await postCycleTransition(token, trade.cycle_id, { event: "expire_otm" });
+        const defaultExpiredAt = new Date().toISOString().slice(0, 10);
+        const expiredAtInput = window.prompt("Expired at (YYYY-MM-DD)", defaultExpiredAt);
+        if (expiredAtInput === null) return;
+        const expireTypeInput = window.prompt(
+          "Expire type: expired_worthless or expired_itm",
+          "expired_worthless"
+        );
+        if (expireTypeInput === null) return;
+        const normalizedType = expireTypeInput.trim().toLowerCase();
+        if (normalizedType !== "expired_worthless" && normalizedType !== "expired_itm") {
+          setSaveError("Invalid expire type. Use expired_worthless or expired_itm.");
+          return;
         }
-        const updated = await updateTrade(token, trade.id, { status: "EXPIRED" });
+
+        const updated = await expireTrade(token, trade.id, {
+          expired_at: expiredAtInput,
+          expire_type: normalizedType,
+        });
         setAllTrades((prev) => prev.map((t) => (t.id === trade.id ? updated : t)));
         return;
       }
@@ -195,6 +218,7 @@ export default function TradesPage() {
             type="button"
             onClick={() => {
               setSaveError(null);
+              setEditingTrade(null);
               setModalOpen(true);
             }}
             className="shrink-0 rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-medium text-white hover:bg-gray-800"
@@ -223,6 +247,7 @@ export default function TradesPage() {
             loading={tradesLoading}
             onAddTrade={() => {
               setSaveError(null);
+              setEditingTrade(null);
               setModalOpen(true);
             }}
             onDeleteTrade={onDeleteTrade}
@@ -234,9 +259,30 @@ export default function TradesPage() {
 
       <AddTradeModal
         open={modalOpen}
-        onClose={() => setModalOpen(false)}
-        onSave={onSaveTrade}
+        onClose={() => {
+          setModalOpen(false);
+          setEditingTrade(null);
+        }}
+        onSave={editingTrade ? onSaveEditedTrade : onSaveTrade}
         tickerSuggestions={tickerSuggestions}
+        initialValues={
+          editingTrade
+            ? {
+                ticker: editingTrade.ticker,
+                option_type: editingTrade.option_type,
+                strike: editingTrade.strike,
+                expiry: editingTrade.expiry,
+                trade_date: editingTrade.trade_date,
+                premium: editingTrade.premium,
+                contracts: editingTrade.contracts,
+                delta: editingTrade.delta,
+                status: editingTrade.status,
+                notes: editingTrade.notes,
+              }
+            : undefined
+        }
+        title={editingTrade ? "Edit Trade" : "Add Trade"}
+        submitLabel={editingTrade ? "Update Trade" : "Save Trade"}
       />
     </>
   );

--- a/apps/web/lib/api/trades.ts
+++ b/apps/web/lib/api/trades.ts
@@ -20,6 +20,8 @@ export interface Trade {
   contracts: number;
   delta?: number;
   status: TradeStatus;
+  expired_at?: string | null;
+  expire_type?: "EXPIRED_WORTHLESS" | "EXPIRED_ITM" | null;
   notes?: string;
 }
 
@@ -73,6 +75,11 @@ export interface DashboardInsights {
 export interface CycleTransitionInput {
   event: "expire_otm" | "assigned" | "roll";
   params?: Record<string, unknown>;
+}
+
+export interface ExpireTradeInput {
+  expired_at: string;
+  expire_type?: "expired_worthless" | "expired_itm";
 }
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
@@ -207,4 +214,18 @@ export async function postCycleTransition(
   input: CycleTransitionInput
 ): Promise<void> {
   return realPostCycleTransition(_token, cycleId, input);
+}
+
+export async function expireTrade(
+  _token: string,
+  id: string,
+  input: ExpireTradeInput
+): Promise<Trade> {
+  const res = await fetch(`${API_BASE}/api/trades/${id}/expire`, {
+    method: "PATCH",
+    headers: authHeaders(_token),
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw new Error(await getErrorMessage(res, "Failed to expire trade"));
+  return res.json() as Promise<Trade>;
 }

--- a/backend/migrations/versions/0002_trade_expire_fields.py
+++ b/backend/migrations/versions/0002_trade_expire_fields.py
@@ -1,0 +1,26 @@
+"""Add trade expiration metadata fields.
+
+Revision ID: 0002_trade_expire_fields
+Revises: 0001_initial_schema
+Create Date: 2026-04-29
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002_trade_expire_fields"
+down_revision: Union[str, None] = "0001_initial_schema"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("trades", sa.Column("expired_at", sa.Date(), nullable=True))
+    op.add_column("trades", sa.Column("expire_type", sa.String(length=30), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("trades", "expire_type")
+    op.drop_column("trades", "expired_at")

--- a/backend/models/trade.py
+++ b/backend/models/trade.py
@@ -11,6 +11,7 @@ from backend.models import db
 ALLOWED_TRADE_STATUSES = frozenset(
     {"OPEN", "CLOSED", "ASSIGNED", "CALLED_AWAY", "EXPIRED", "ROLLED"}
 )
+ALLOWED_EXPIRE_TYPES = frozenset({"EXPIRED_WORTHLESS", "EXPIRED_ITM"})
 
 
 class Trade(db.Model):
@@ -31,6 +32,8 @@ class Trade(db.Model):
     delta: Mapped[float | None] = mapped_column(Numeric(5, 3), nullable=True)
     contracts: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="OPEN")
+    expired_at: Mapped[date | None] = mapped_column(Date, nullable=True)
+    expire_type: Mapped[str | None] = mapped_column(String(30), nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
@@ -64,6 +67,8 @@ class Trade(db.Model):
             "delta": float(self.delta) if self.delta is not None else None,
             "contracts": self.contracts,
             "status": self.status,
+            "expired_at": self.expired_at.isoformat() if self.expired_at else None,
+            "expire_type": self.expire_type,
             "notes": self.notes,
             "cycle_id": self.cycle_id,
             "created_at": self.created_at.isoformat().replace("+00:00", "Z")

--- a/backend/routes/trades.py
+++ b/backend/routes/trades.py
@@ -6,7 +6,7 @@ from flask import request, jsonify
 
 from backend.auth.supabase import require_auth
 from backend.models import db
-from backend.models.trade import ALLOWED_TRADE_STATUSES, Trade
+from backend.models.trade import ALLOWED_EXPIRE_TYPES, ALLOWED_TRADE_STATUSES, Trade
 from backend.models.wheel_cycle import WheelCycle
 
 
@@ -132,8 +132,58 @@ def register_trades_routes(trades_bp):
             if st not in ALLOWED_TRADE_STATUSES:
                 return jsonify({"error": f"Invalid status; allowed: {sorted(ALLOWED_TRADE_STATUSES)}"}), 400
             trade.status = st
+            if st != "EXPIRED":
+                trade.expired_at = None
+                trade.expire_type = None
 
         trade.updated_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return jsonify(trade.to_api_dict())
+
+    @trades_bp.route("/<trade_id>/expire", methods=["PATCH"])
+    @require_auth
+    def expire_trade(user_id: str, trade_id: str):
+        trade = Trade.query.filter_by(id=trade_id, user_id=user_id).first_or_404()
+        data = request.get_json() or {}
+
+        if trade.status != "OPEN":
+            return jsonify({"error": "Only OPEN trades can be marked as expired"}), 400
+
+        try:
+            expired_at = date.fromisoformat(str(data.get("expired_at") or date.today().isoformat()))
+        except ValueError:
+            return jsonify({"error": "Invalid expired_at date format; use YYYY-MM-DD"}), 400
+
+        expire_type_raw = data.get("expire_type", "expired_worthless")
+        expire_type = str(expire_type_raw).upper()
+        if expire_type not in ALLOWED_EXPIRE_TYPES:
+            return jsonify(
+                {"error": f"Invalid expire_type; allowed: {sorted(ALLOWED_EXPIRE_TYPES)}"}
+            ), 400
+
+        if trade.expiry > expired_at:
+            return jsonify({"error": "Trade cannot be expired before its expiry date"}), 400
+
+        trade.status = "EXPIRED"
+        trade.expired_at = expired_at
+        trade.expire_type = expire_type
+        trade.updated_at = datetime.now(timezone.utc)
+
+        if trade.cycle_id:
+            cycle = WheelCycle.query.filter_by(id=trade.cycle_id, user_id=user_id).first()
+            if cycle:
+                from backend.services.cycle_fsm import append_transition, apply_api_event, replay_cycle
+                from cycleiq.wheel_fsm import InvalidTransitionError
+
+                try:
+                    fsm_cycle = replay_cycle(cycle.ticker, cycle.transition_log)
+                    transition = apply_api_event(fsm_cycle, "expire_otm", {})
+                    cycle.transition_log = append_transition(cycle.transition_log, transition)
+                    cycle.state = fsm_cycle.state.value
+                except (InvalidTransitionError, ValueError, KeyError, TypeError):
+                    # Keep trade expiry update even if cycle transition is not applicable.
+                    pass
+
         db.session.commit()
         return jsonify(trade.to_api_dict())
 


### PR DESCRIPTION
## Summary
- add backend trade expiration metadata support (expired_at, expire_type) with new migration and API response fields
- implement PATCH /api/trades/{id}/expire to validate open trades, persist expiration metadata, and sync wheel cycle FSM transition when applicable
- update trades UI to reuse the Add Trade modal for full-field Edit, and show Expire action only for open trades that are at/after expiry date
- wire frontend to new expireTrade API and collect expiration date/type during confirmation flow

## Test plan
- [x] ReadLints on changed files reports no new lint errors
- [x] 
pm run lint in pps/web (fails due to pre-existing repo-wide lint errors unrelated to this PR)
- [ ] run backend migration: lask db upgrade
- [ ] manually verify in Trades UI:
  - [ ] Edit opens full form with existing values and title Edit Trade
  - [ ] Expire action appears only on OPEN trades where expiry <= today
  - [ ] Expire saves status=EXPIRED, expired_at, and expire_type

Closes #63.

Made with [Cursor](https://cursor.com)