### PR TITLE
Make sidebar collapsible and improve Trades/Cycles responsiveness

### DIFF
--- a/apps/web/app/(protected)/cycles/page.tsx
+++ b/apps/web/app/(protected)/cycles/page.tsx
@@ -319,8 +319,8 @@ export default function CyclesPage() {
   if (isAuthLoading) return null;
 
   return (
-    <main className="bg-slate-50 px-6 py-6">
-      <div className="mx-auto max-w-7xl space-y-4">
+    <main className="h-full bg-slate-50 px-4 py-4 sm:px-6 sm:py-6">
+      <div className="w-full space-y-4">
         <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>

--- a/apps/web/app/(protected)/layout.tsx
+++ b/apps/web/app/(protected)/layout.tsx
@@ -23,6 +23,7 @@ export default function ProtectedLayout({
   const [token, setToken] = useState<string | null>(null);
   const [isAuthLoading, setIsAuthLoading] = useState(true);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   const pageTitle = PAGE_TITLES[pathname] ?? "CycleIQ";
 
@@ -87,7 +88,7 @@ export default function ProtectedLayout({
             sidebarOpen ? "translate-x-0" : "-translate-x-full"
           }`}
         >
-          <Sidebar email={email} onLogout={() => void onLogout()} />
+          <Sidebar collapsed={sidebarCollapsed} />
         </div>
 
         {/* Main content column */}
@@ -105,6 +106,14 @@ export default function ProtectedLayout({
                 ☰
               </button>
               <h1 className="text-sm font-semibold text-slate-900">{pageTitle}</h1>
+              <button
+                type="button"
+                onClick={() => setSidebarCollapsed((prev) => !prev)}
+                className="hidden rounded-lg px-2 py-1 text-xs text-slate-500 hover:bg-slate-100 lg:inline-flex"
+                aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+              >
+                {sidebarCollapsed ? "»" : "«"}
+              </button>
             </div>
 
             <div className="flex items-center gap-3">

--- a/apps/web/app/(protected)/trades/page.tsx
+++ b/apps/web/app/(protected)/trades/page.tsx
@@ -212,8 +212,8 @@ export default function TradesPage() {
   if (isAuthLoading) return null;
   return (
     <>
-      <main className="bg-slate-50 px-6 py-6">
-        <div className="mx-auto max-w-7xl">
+      <main className="h-full bg-slate-50 px-4 py-4 sm:px-6 sm:py-6">
+        <div className="w-full">
         {saveError && (
           <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700">
             {saveError}

--- a/apps/web/app/components/Sidebar.tsx
+++ b/apps/web/app/components/Sidebar.tsx
@@ -20,18 +20,17 @@ const navItems: { label: string; href: string; icon: LucideIcon }[] = [
 ];
 
 interface SidebarProps {
-  email?: string | null;
-  onLogout?: () => void;
+  collapsed?: boolean;
 }
 
-export default function Sidebar({ email, onLogout }: SidebarProps) {
+export default function Sidebar({ collapsed = false }: SidebarProps) {
   const pathname = usePathname();
 
   return (
-    <aside className="flex h-full w-60 shrink-0 flex-col bg-slate-900">
-      <div className="flex h-14 items-center px-5">
+    <aside className={`flex h-full shrink-0 flex-col bg-slate-900 transition-all duration-200 ${collapsed ? "w-16" : "w-60"}`}>
+      <div className={`flex h-14 items-center ${collapsed ? "justify-center px-2" : "px-5"}`}>
         <Link href="/dashboard" className="text-base font-bold tracking-tight text-white">
-          CycleIQ
+          {collapsed ? "CIQ" : "CycleIQ"}
         </Link>
       </div>
 
@@ -43,39 +42,19 @@ export default function Sidebar({ email, onLogout }: SidebarProps) {
             <Link
               key={item.href}
               href={item.href}
-              className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+              className={`flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                 isActive
                   ? "bg-emerald-500/10 text-emerald-400 ring-1 ring-inset ring-emerald-500/20"
                   : "text-slate-400 hover:bg-slate-800 hover:text-white"
-              }`}
+              } ${collapsed ? "justify-center" : "gap-2.5"}`}
+              title={item.label}
             >
               <Icon className="h-4 w-4 shrink-0" />
-              <span>{item.label}</span>
+              {!collapsed && <span>{item.label}</span>}
             </Link>
           );
         })}
       </nav>
-
-      <div className="border-t border-slate-800 px-4 py-3">
-        <div className="flex items-center gap-2.5">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-700 text-sm font-medium text-slate-200">
-            {email ? email[0].toUpperCase() : "?"}
-          </div>
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-xs text-slate-400">{email ?? "Signed in"}</p>
-          </div>
-          {onLogout && (
-            <button
-              type="button"
-              onClick={onLogout}
-              className="text-xs text-slate-500 hover:text-white transition-colors"
-              title="Logout"
-            >
-              ↩
-            </button>
-          )}
-        </div>
-      </div>
     </aside>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a desktop collapsible sidebar to save horizontal space and support icon-only navigation when needed.
- Remove the duplicate logout affordance in the sidebar since `Sign out` already exists in the header.
- Make the Trades and Cycles pages adapt to window size instead of constraining content to a fixed max width.

### Description
- Refactored `Sidebar` to accept a `collapsed` prop and render a compact `w-16` icon-only layout when collapsed, hiding the bottom account/logout row (`apps/web/app/components/Sidebar.tsx`).
- Added `sidebarCollapsed` state and a header toggle button to the protected layout and passed the `collapsed` prop into `Sidebar` (`apps/web/app/(protected)/layout.tsx`).
- Replaced fixed centered containers on Trades and Cycles pages by switching from `mx-auto max-w-7xl` to full-width responsive wrappers with adjusted padding (`apps/web/app/(protected)/trades/page.tsx`, `apps/web/app/(protected)/cycles/page.tsx`).
- Adjusted sidebar item classes to center icons and expose labels only when expanded, and added `title` attributes for collapsed navigation items (`apps/web/app/components/Sidebar.tsx`).

### Testing
- Ran the lint task with `npm --prefix apps/web run lint`; lint ran and reported pre-existing warnings/errors in unrelated files (for example `TradeDetailModal.tsx`, `TradeFilters.tsx`, and `useTradeDefaults.ts`) and did not introduce new lint failures in modified files.
- No additional automated unit or integration tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f77d950148322b4ff09992de00619)