### PR TITLE
Support called-away flow: backend propagation and UI adjustments

### DIFF
--- a/apps/web/app/(protected)/cycles/page.tsx
+++ b/apps/web/app/(protected)/cycles/page.tsx
@@ -89,6 +89,12 @@ interface WheelSummary extends CycleSummary {
 function deriveWheelState(wheelTrades: Trade[], cycleState: string): string {
   const hasOpen = wheelTrades.some((t) => t.status === "OPEN");
   if (hasOpen) return cycleState.startsWith("CC") ? cycleState : "CSP_OPEN";
+
+  const hasCalledAwayCall = wheelTrades.some(
+    (t) => t.option_type === "CALL" && t.status === "CALLED_AWAY"
+  );
+  if (hasCalledAwayCall) return "CSP_CLOSED";
+
   // PUT was assigned → user holds stock, not completed
   const hasAssigned = wheelTrades.some((t) => t.status === "ASSIGNED" && t.option_type === "PUT");
   if (hasAssigned) return "STOCK_HELD";

--- a/apps/web/app/(protected)/trades/components/TradeDetailModal.tsx
+++ b/apps/web/app/(protected)/trades/components/TradeDetailModal.tsx
@@ -474,7 +474,7 @@ export default function TradeDetailModal({
             {/* ── primary actions ── */}
             <div className="flex flex-wrap justify-center gap-2">
               {(
-                trade.status === "ASSIGNED"
+                trade.status === "ASSIGNED" || (trade.option_type === "PUT" && trade.status === "EXPIRED")
                   ? [
                       { label: "Edit", Icon: IcPencil, onClick: () => { onClose(); onEdit(trade); } },
                     ]

--- a/apps/web/app/(protected)/trades/components/TradeFilters.tsx
+++ b/apps/web/app/(protected)/trades/components/TradeFilters.tsx
@@ -312,7 +312,7 @@ export default function TradeFilters({
         </div>
         <div className="min-w-[360px] flex-1 overflow-x-auto">
           <div className="flex w-max min-w-full items-center gap-1 rounded-full bg-[#eef0f4] p-1">
-          {STATUS_ROW.map(({ key, label, Icon }) => {
+          {STATUS_ROW.filter(({ key }) => !(filters.type === "PUT" && key === "CALLED_AWAY")).map(({ key, label, Icon }) => {
             const active = filters.status === key;
             return (
               <button

--- a/apps/web/app/(protected)/trades/components/TradeList.tsx
+++ b/apps/web/app/(protected)/trades/components/TradeList.tsx
@@ -476,7 +476,9 @@ function TradeRow({
               >
                 Edit
               </button>
-              {trade.status !== "ASSIGNED" && trade.status !== "ROLLED" && (
+              {trade.status !== "ASSIGNED" &&
+                trade.status !== "ROLLED" &&
+                !(trade.option_type === "PUT" && trade.status === "EXPIRED") && (
                 <>
                   <button
                     type="button"

--- a/backend/routes/trades.py
+++ b/backend/routes/trades.py
@@ -345,6 +345,23 @@ def register_trades_routes(trades_bp):
                 if chain_premium > 0:
                     trade.prior_roll_premium_per_share = float(chain_premium)
 
+            if st == "CALLED_AWAY" and trade.option_type == "CALL" and trade.cycle_id:
+                assigned_put = (
+                    Trade.query.filter_by(user_id=user_id, cycle_id=trade.cycle_id, option_type="PUT")
+                    .filter(Trade.status.in_(["ASSIGNED", "OPEN"]))
+                    .order_by(Trade.trade_date.desc(), Trade.created_at.desc())
+                    .first()
+                )
+                if assigned_put:
+                    assigned_put.status = "CALLED_AWAY"
+                    assigned_put.called_away_at = trade.called_away_at or trade.trade_date
+                    assigned_put.updated_at = datetime.now(timezone.utc)
+                    apply_stock_cost_basis(assigned_put)
+
+                cycle = WheelCycle.query.filter_by(id=trade.cycle_id, user_id=user_id).first()
+                if cycle:
+                    cycle.state = "CSP_CLOSED"
+
         trade.updated_at = datetime.now(timezone.utc)
         apply_stock_cost_basis(trade)
         db.session.commit()


### PR DESCRIPTION
### Motivation
- Ensure a "called away" CALL properly closes the CSP wheel and update UI to avoid showing invalid actions/statuses for PUTs that were called away or expired.

### Description
- Update `deriveWheelState` to detect a `CALL` with `status === "CALLED_AWAY"` and return `"CSP_CLOSED"` for the wheel state.  
- In the frontend modal (`TradeDetailModal.tsx`) treat a `PUT` with `status === "EXPIRED"` like `ASSIGNED` for primary actions so only the Edit action is shown.  
- In `TradeFilters.tsx` remove the `CALLED_AWAY` status button when `filters.type === "PUT"` so the status row does not show an irrelevant status.  
- In `TradeList.tsx` hide action menu entries (e.g. `Buy to Close`, `Expire`) for `PUT` trades that are `EXPIRED`.  
- In the backend `/trades` update flow, when a `CALL` trade is set to `CALLED_AWAY` propagate that to the matching `PUT` in the same `cycle_id` by marking it `CALLED_AWAY`, setting `called_away_at`, applying `apply_stock_cost_basis`, and setting the corresponding `WheelCycle.state` to `"CSP_CLOSED"`.

### Testing
- Ran the backend test suite including trade route tests and all tests passed.  
- Ran the frontend typecheck and build, and unit/UI tests, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1352fbb2c08322a4685ed77924fea5)