### PR TITLE
Mark CSP wheels closed on call-away and update UI/filters for closed wheels and expired PUTs

### DIFF
--- a/apps/web/app/(protected)/cycles/page.tsx
+++ b/apps/web/app/(protected)/cycles/page.tsx
@@ -89,6 +89,12 @@ interface WheelSummary extends CycleSummary {
 function deriveWheelState(wheelTrades: Trade[], cycleState: string): string {
   const hasOpen = wheelTrades.some((t) => t.status === "OPEN");
   if (hasOpen) return cycleState.startsWith("CC") ? cycleState : "CSP_OPEN";
+
+  const hasCalledAwayCall = wheelTrades.some(
+    (t) => t.option_type === "CALL" && t.status === "CALLED_AWAY"
+  );
+  if (hasCalledAwayCall) return "CSP_CLOSED";
+
   // PUT was assigned → user holds stock, not completed
   const hasAssigned = wheelTrades.some((t) => t.status === "ASSIGNED" && t.option_type === "PUT");
   if (hasAssigned) return "STOCK_HELD";
@@ -190,11 +196,11 @@ export default function CyclesPage() {
   );
 
   const activeCycles = useMemo(
-    () => sortedCycles.filter((cycle) => cycle.state !== "EXIT"),
+    () => sortedCycles.filter((cycle) => cycle.state !== "EXIT" && cycle.state !== "CSP_CLOSED"),
     [sortedCycles]
   );
   const completedCycles = useMemo(
-    () => sortedCycles.filter((cycle) => cycle.state === "EXIT"),
+    () => sortedCycles.filter((cycle) => cycle.state === "EXIT" || cycle.state === "CSP_CLOSED"),
     [sortedCycles]
   );
   const tabCycles =

--- a/apps/web/app/(protected)/trades/components/TradeDetailModal.tsx
+++ b/apps/web/app/(protected)/trades/components/TradeDetailModal.tsx
@@ -474,7 +474,7 @@ export default function TradeDetailModal({
             {/* ── primary actions ── */}
             <div className="flex flex-wrap justify-center gap-2">
               {(
-                trade.status === "ASSIGNED"
+                trade.status === "ASSIGNED" || (trade.option_type === "PUT" && trade.status === "EXPIRED")
                   ? [
                       { label: "Edit", Icon: IcPencil, onClick: () => { onClose(); onEdit(trade); } },
                     ]

--- a/apps/web/app/(protected)/trades/components/TradeFilters.tsx
+++ b/apps/web/app/(protected)/trades/components/TradeFilters.tsx
@@ -312,7 +312,7 @@ export default function TradeFilters({
         </div>
         <div className="min-w-[360px] flex-1 overflow-x-auto">
           <div className="flex w-max min-w-full items-center gap-1 rounded-full bg-[#eef0f4] p-1">
-          {STATUS_ROW.map(({ key, label, Icon }) => {
+          {STATUS_ROW.filter(({ key }) => !(filters.type === "PUT" && key === "CALLED_AWAY")).map(({ key, label, Icon }) => {
             const active = filters.status === key;
             return (
               <button

--- a/apps/web/app/(protected)/trades/components/TradeList.tsx
+++ b/apps/web/app/(protected)/trades/components/TradeList.tsx
@@ -476,7 +476,9 @@ function TradeRow({
               >
                 Edit
               </button>
-              {trade.status !== "ASSIGNED" && trade.status !== "ROLLED" && (
+              {trade.status !== "ASSIGNED" &&
+                trade.status !== "ROLLED" &&
+                !(trade.option_type === "PUT" && trade.status === "EXPIRED") && (
                 <>
                   <button
                     type="button"

--- a/apps/web/app/(protected)/trades/page.tsx
+++ b/apps/web/app/(protected)/trades/page.tsx
@@ -58,6 +58,16 @@ function applyFilters(trades: Trade[], f: FilterState): Trade[] {
     // Closed wheels should not show in the dedicated "Rolled" status tab.
     if (f.status === "ROLLED" && t.cycle_id && closedCycleIds.has(t.cycle_id)) return false;
 
+    // CSP-assigned views should not include positions from wheels already closed/called-away.
+    if (
+      f.status === "ASSIGNED" &&
+      t.option_type === "PUT" &&
+      t.cycle_id &&
+      closedCycleIds.has(t.cycle_id)
+    ) {
+      return false;
+    }
+
     if (
       f.search &&
       !t.ticker.toLowerCase().includes(f.search.toLowerCase()) &&

--- a/apps/web/app/(protected)/trades/page.tsx
+++ b/apps/web/app/(protected)/trades/page.tsx
@@ -25,10 +25,39 @@ function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+function getClosedCycleIds(trades: Trade[]): Set<string> {
+  const cycleTrades = trades.reduce<Record<string, Trade[]>>((acc, t) => {
+    if (!t.cycle_id) return acc;
+    if (!acc[t.cycle_id]) acc[t.cycle_id] = [];
+    acc[t.cycle_id].push(t);
+    return acc;
+  }, {});
+
+  return new Set(
+    Object.entries(cycleTrades)
+      .filter(([, ts]) => {
+        const hasCalledAway = ts.some(
+          (t) =>
+            (t.option_type === "CALL" || t.option_type === "PUT") &&
+            t.status === "CALLED_AWAY"
+        );
+        const hasOpen = ts.some((t) => t.status === "OPEN");
+        return hasCalledAway || !hasOpen;
+      })
+      .map(([cycleId]) => cycleId)
+  );
+}
+
 function applyFilters(trades: Trade[], f: FilterState): Trade[] {
+  const closedCycleIds = getClosedCycleIds(trades);
+
   return trades.filter((t) => {
     if (f.type !== "ALL" && t.option_type !== f.type) return false;
     if (f.status !== "ALL" && t.status !== f.status) return false;
+
+    // Closed wheels should not show in the dedicated "Rolled" status tab.
+    if (f.status === "ROLLED" && t.cycle_id && closedCycleIds.has(t.cycle_id)) return false;
+
     if (
       f.search &&
       !t.ticker.toLowerCase().includes(f.search.toLowerCase()) &&
@@ -82,24 +111,38 @@ export default function TradesPage() {
   );
 
   // Tickers that have an assigned (stock-held) position, i.e. CSP that was assigned.
-  const assignedTickers = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          allTrades
-            .filter((t) => t.option_type === "PUT" && t.status === "ASSIGNED")
-            .map((t) => t.ticker)
-        )
-      ),
-    [allTrades]
-  );
+  // Exclude wheels that are already closed (no OPEN legs), including called-away wheels.
+  const assignedTickers = useMemo(() => {
+    const closedCycleIds = getClosedCycleIds(allTrades);
+
+    return Array.from(
+      new Set(
+        allTrades
+          .filter(
+            (t) =>
+              t.option_type === "PUT" &&
+              t.status === "ASSIGNED" &&
+              (t.cycle_id && !closedCycleIds.has(t.cycle_id))
+          )
+          .map((t) => t.ticker)
+      )
+    );
+  }, [allTrades]);
 
   // Map ticker → cycle_id for ASSIGNED PUT trades (most recent per ticker).
   // Used to explicitly link new CC trades to the correct existing wheel.
   const assignedCycleByTicker = useMemo(() => {
+    const closedCycleIds = getClosedCycleIds(allTrades);
+
     const map: Record<string, string> = {};
     allTrades
-      .filter((t) => t.option_type === "PUT" && t.status === "ASSIGNED" && t.cycle_id)
+      .filter(
+        (t) =>
+          t.option_type === "PUT" &&
+          t.status === "ASSIGNED" &&
+          t.cycle_id &&
+          !closedCycleIds.has(t.cycle_id)
+      )
       .sort((a, b) => new Date(a.trade_date).getTime() - new Date(b.trade_date).getTime())
       .forEach((t) => {
         if (t.cycle_id) map[t.ticker] = t.cycle_id;

--- a/apps/web/app/(protected)/trades/page.tsx
+++ b/apps/web/app/(protected)/trades/page.tsx
@@ -67,7 +67,6 @@ function applyFilters(trades: Trade[], f: FilterState): Trade[] {
     ) {
       return false;
     }
-
     if (
       f.search &&
       !t.ticker.toLowerCase().includes(f.search.toLowerCase()) &&
@@ -132,7 +131,7 @@ export default function TradesPage() {
             (t) =>
               t.option_type === "PUT" &&
               t.status === "ASSIGNED" &&
-              (t.cycle_id && !closedCycleIds.has(t.cycle_id))
+              (!t.cycle_id || !closedCycleIds.has(t.cycle_id))
           )
           .map((t) => t.ticker)
       )

--- a/backend/routes/trades.py
+++ b/backend/routes/trades.py
@@ -345,6 +345,23 @@ def register_trades_routes(trades_bp):
                 if chain_premium > 0:
                     trade.prior_roll_premium_per_share = float(chain_premium)
 
+            if st == "CALLED_AWAY" and trade.option_type == "CALL" and trade.cycle_id:
+                assigned_put = (
+                    Trade.query.filter_by(user_id=user_id, cycle_id=trade.cycle_id, option_type="PUT")
+                    .filter(Trade.status.in_(["ASSIGNED", "OPEN"]))
+                    .order_by(Trade.trade_date.desc(), Trade.created_at.desc())
+                    .first()
+                )
+                if assigned_put:
+                    assigned_put.status = "CALLED_AWAY"
+                    assigned_put.called_away_at = trade.called_away_at or trade.trade_date
+                    assigned_put.updated_at = datetime.now(timezone.utc)
+                    apply_stock_cost_basis(assigned_put)
+
+                cycle = WheelCycle.query.filter_by(id=trade.cycle_id, user_id=user_id).first()
+                if cycle:
+                    cycle.state = "CSP_CLOSED"
+
         trade.updated_at = datetime.now(timezone.utc)
         apply_stock_cost_basis(trade)
         db.session.commit()


### PR DESCRIPTION
### Motivation
- Ensure that a CALL marked `CALLED_AWAY` closes its associated CSP wheel so the system treats the wheel as completed instead of active. 
- Prevent closed wheels (including those closed via call-away) from showing up in active/rolled UI contexts and from being considered when linking new CC trades. 
- Treat expired PUT legs that represent closed wheels consistently in action menus and modals so users cannot perform inappropriate actions.

### Description
- Backend: when a CALL trade is updated to `CALLED_AWAY`, the server now marks the paired PUT in the same `cycle_id` as `CALLED_AWAY`, sets `called_away_at`, applies stock cost basis, and sets the cycle `state` to `CSP_CLOSED` (`backend/routes/trades.py`).
- Cycles UI: `deriveWheelState` now returns `CSP_CLOSED` when a wheel contains a called-away CALL, and the cycles listing treats `CSP_CLOSED` as a completed state instead of active (`apps/web/app/(protected)/cycles/page.tsx`).
- Trades logic: added `getClosedCycleIds` and used it to hide closed wheels from the `ROLLED` status tab and to exclude closed cycles from `assignedTickers` and `assignedCycleByTicker` mapping (`apps/web/app/(protected)/trades/page.tsx`).
- Trade list / modal / filters: hide `CALLED_AWAY` status option when filtering for PUTs, prevent `Buy to Close`/`Expire` actions for PUT trades that are `EXPIRED`, and treat expired PUTs like assigned ones for primary action rendering so inappropriate actions are not presented (`TradeFilters.tsx`, `TradeList.tsx`, `TradeDetailModal.tsx`).

### Testing
- Ran backend unit tests with `pytest` and database-backed tests related to trade lifecycle, which passed. 
- Ran frontend typecheck and build (`yarn build`) to validate TypeScript and bundling, which completed successfully. 
- Ran the web app's automated UI tests and status-filter related tests, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1352fbb2c08322a4685ed77924fea5)