### PR TITLE
Improve wheel diagram default size and zoom sharpness

### DIFF
--- a/apps/web/app/components/PanZoomStage.tsx
+++ b/apps/web/app/components/PanZoomStage.tsx
@@ -39,7 +39,7 @@ export default function PanZoomStage({
   height,
   className,
   minScale = 0.25,
-  maxScale = 3,
+  maxScale = 5,
   labels,
   children,
 }: PanZoomStageProps) {
@@ -144,7 +144,7 @@ export default function PanZoomStage({
       ref={viewportRef}
       className={`relative w-full overflow-hidden ${className ?? ""}`}
       style={{
-        height: Math.max(340, Math.min(height, 600)),
+        height: Math.max(460, Math.min(height, 760)),
         touchAction: "none",
         cursor: dragging ? "grabbing" : "grab",
       }}
@@ -162,7 +162,6 @@ export default function PanZoomStage({
           height,
           transformOrigin: "0 0",
           transform: `translate(${t.tx}px, ${t.ty}px) scale(${t.scale})`,
-          willChange: "transform",
         }}
       >
         {children}


### PR DESCRIPTION
## Summary
- Enlarge the wheel diagram `PanZoomStage` viewport so the diagram is larger and more legible by default.
- Drop `will-change: transform` so card text re-rasterizes crisply when zoomed in (fixes blurriness on zoom).
- Raise the max zoom level to 5x.

## Test plan
- [x] `tsc --noEmit` passes for `apps/web`
- [ ] CI required status checks pass
- [ ] Verify the wheel diagram is larger by default and stays sharp when zoomed in
