### PR TITLE
Show all prices with two decimal places

### DIFF
--- a/apps/web/app/(protected)/cycles/page.tsx
+++ b/apps/web/app/(protected)/cycles/page.tsx
@@ -437,11 +437,11 @@ export default function CyclesPage() {
                     </div>
                     <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5">
                       <p className="text-[11px] font-medium uppercase tracking-wider text-slate-600">{t("cc.premiumRealized")}</p>
-                      <p className="mt-1 text-lg font-semibold tabular-nums text-slate-900">${row.ccPremiumTotal.toFixed(0)}</p>
+                      <p className="mt-1 text-lg font-semibold tabular-nums text-slate-900">${row.ccPremiumTotal.toFixed(2)}</p>
                       <p className="text-xs text-slate-600">
                         {row.ccPremiumRealized < row.ccPremiumTotal
                           ? t("cc.premiumRealizedHint", {
-                              realized: `$${row.ccPremiumRealized.toFixed(0)}`,
+                              realized: `$${row.ccPremiumRealized.toFixed(2)}`,
                             })
                           : t("total")}
                       </p>
@@ -656,7 +656,7 @@ export default function CyclesPage() {
                           completed ? "text-[14px]" : "text-[11px] font-semibold"
                         } ${totalNet < 0 ? "text-red-700" : completed ? "text-amber-900" : "text-emerald-700"}`}
                       >
-                        {totalNet < 0 ? "−" : "+"}${Math.abs(totalNet).toFixed(0)}
+                        {totalNet < 0 ? "−" : "+"}${Math.abs(totalNet).toFixed(2)}
                       </div>
                       {completed && (
                         <span className="mt-0.5 text-[9px] font-semibold uppercase tracking-wide text-amber-700/90">
@@ -684,7 +684,7 @@ export default function CyclesPage() {
                               </p>
                             </div>
                             <p className="text-[28px] font-bold leading-none tabular-nums text-slate-900">
-                              ${trade.strike.toFixed(0)}
+                              ${trade.strike.toFixed(2)}
                             </p>
                             <p className={`text-sm font-semibold tabular-nums ${isDebit ? "text-red-600" : "text-emerald-700"}`}>
                               {isDebit ? "−" : "+"}${Math.abs(net).toFixed(2)}
@@ -839,7 +839,7 @@ export default function CyclesPage() {
                                   ${trade.strike.toFixed(2)}
                                 </p>
                                 <p className="text-sm font-semibold tabular-nums text-emerald-700">
-                                  +${(trade.premium * trade.contracts * 100).toFixed(0)}
+                                  +${(trade.premium * trade.contracts * 100).toFixed(2)}
                                 </p>
                                 <p className="mt-1 text-xs text-slate-600">{fmtDate(trade.expiry, intlLocale)}</p>
                                 <span className="mt-1.5 inline-flex rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-800 ring-1 ring-slate-200/80">

--- a/apps/web/app/(protected)/dashboard/components/AddTradeModal.tsx
+++ b/apps/web/app/(protected)/dashboard/components/AddTradeModal.tsx
@@ -43,7 +43,10 @@ const LOGO_URL_BUILDERS = [
 ];
 
 function fmtMoneyCompact(value: number, intlLocale: string): string {
-  return value.toLocaleString(intlLocale, { maximumFractionDigits: 0 });
+  return value.toLocaleString(intlLocale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 }
 
 function getCapitalBudgetErrorMessage(

--- a/apps/web/app/(protected)/dashboard/components/DashboardInsights.tsx
+++ b/apps/web/app/(protected)/dashboard/components/DashboardInsights.tsx
@@ -113,6 +113,7 @@ function fmtCurrency(value: number, intlLocale: string): string {
   return new Intl.NumberFormat(intlLocale, {
     style: "currency",
     currency: "USD",
+    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(value);
 }

--- a/apps/web/app/(protected)/dashboard/components/SummaryCards.tsx
+++ b/apps/web/app/(protected)/dashboard/components/SummaryCards.tsx
@@ -6,7 +6,8 @@ function fmt(value: number, style: "currency" | "percent"): string {
     return new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: "USD",
-      maximumFractionDigits: 0,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
     }).format(value);
   }
   return `${value.toFixed(1)}%`;

--- a/apps/web/app/(protected)/trades/components/TradeDetailModal.tsx
+++ b/apps/web/app/(protected)/trades/components/TradeDetailModal.tsx
@@ -314,7 +314,10 @@ export default function TradeDetailModal({
                 },
                 {
                   label: "Capital at Risk",
-                  value: `$${cap.toLocaleString(undefined, { minimumFractionDigits: 0 })}`,
+                  value: `$${cap.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}`,
                   green: false,
                 },
               ].map(({ label, value, green }) => (

--- a/apps/web/lib/cycles/ccCostBasis.ts
+++ b/apps/web/lib/cycles/ccCostBasis.ts
@@ -381,7 +381,7 @@ export function buildCcCostBasisRow(
 
   const primaryPut = assignedPuts[assignedPuts.length - 1]!;
   const assignIso = assignDate ?? primaryPut.trade_date;
-  const subtitle = `$${primaryPut.strike.toFixed(0)} CSP · ${fmtDate(assignIso)}`;
+  const subtitle = `$${primaryPut.strike.toFixed(2)} CSP · ${fmtDate(assignIso)}`;
 
   const recentTradeDate = wheelTrades
     .map((t) => new Date(t.trade_date).getTime())

--- a/apps/web/lib/trades/cspCapital.ts
+++ b/apps/web/lib/trades/cspCapital.ts
@@ -164,7 +164,8 @@ export function capitalBudgetError(
 
   const over = after - pool;
   const pct = capitalUtilizationPct(after, pool);
-  return `Total capital invested $${after.toLocaleString("en-US", { maximumFractionDigits: 0 })} (${pct.toFixed(0)}% of total capital) exceeds your available capital of $${pool.toLocaleString("en-US", { maximumFractionDigits: 0 })} (over by $${over.toLocaleString("en-US", { maximumFractionDigits: 0 })})`;
+  const money = { minimumFractionDigits: 2, maximumFractionDigits: 2 } as const;
+  return `Total capital invested $${after.toLocaleString("en-US", money)} (${pct.toFixed(0)}% of total capital) exceeds your available capital of $${pool.toLocaleString("en-US", money)} (over by $${over.toLocaleString("en-US", money)})`;
 }
 
 /** @deprecated use capitalBudgetError */

--- a/backend/services/csp_capital.py
+++ b/backend/services/csp_capital.py
@@ -86,8 +86,8 @@ def capital_budget_error(
     over = after - budget
     pct = capital_utilization_pct(after, budget)
     return (
-        f"Total capital invested ${after:,.0f} ({pct:.0f}% of total capital) exceeds your "
-        f"available capital of ${budget:,.0f} (over by ${over:,.0f})"
+        f"Total capital invested ${after:,.2f} ({pct:.0f}% of total capital) exceeds your "
+        f"available capital of ${budget:,.2f} (over by ${over:,.2f})"
     )
 
 


### PR DESCRIPTION
## Summary
- Format all dollar amounts with two decimal places instead of rounding to integers
- Covers dashboard, cycles, trade detail, and CSP capital budget messages (web + backend)

## Test plan
- [ ] Dashboard summary/insights show cents on currency values
- [ ] Cycles wheel diagram and CC cost basis show strike/premium with `.xx`
- [ ] CSP over-budget message shows two-decimal dollar amounts
